### PR TITLE
Unbreak regress tests (on OpenBSD for example)

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -57,6 +57,8 @@ Regress-1.0.gir : $(REGRESS)
 	g-ir-scanner --warn-all --no-libtool --quiet --output=$@	\
 	  --namespace=Regress --nsversion=1.0				\
 	  --include=cairo-1.0 --include=Gio-2.0				\
+	  --library-path=/usr/lib --library-path=/usr/X11R6/lib		\
+	  --library-path=/usr/local/lib					\
 	  $(GIDATADIR)/regress.c $(GIDATADIR)/regress.h			\
 	 -lregress
 


### PR DESCRIPTION
Certain platforms require g-ir-scanner to look in some additional directories for libraries. The added directories are fairly generic and will unbreak regress tests on OpenBSD.
Also, if the directory does not exist it's just silently ignored.
