### PR TITLE
set_resident: Clean the stack correctly

### DIFF
--- a/lgi/core.c
+++ b/lgi/core.c
@@ -529,6 +529,7 @@ set_resident (lua_State *L)
 	 upon state cleanup. */
       lua_pushnil (L);
       lua_rawseti (L, -2, lua_objlen (L, -2));
+      lua_pop (L, 1);
       return;
     }
   else


### PR DESCRIPTION
For Lua 5.2, when _CLIBS is available in the registry,
a stray table was accidentally left on the stack.
