### PR TITLE
Cairo: Make the cairo.path() test fail

### DIFF
--- a/tests/cairo.lua
+++ b/tests/cairo.lua
@@ -118,6 +118,7 @@ function cairo.path()
       end
       i = i + 1
    end
+   check(i == 4)
 end
 
 function cairo.surface_type()


### PR DESCRIPTION
I was writing some bindings for functions that are new in cairo 1.12 (However, I have no idea yet what should happen when lgi gets run against cairo 1.10...). While writing tests for cairo_mesh_pattern_get_path(), I noticed that iterating over a path is broken.

However, I haven't managed to figure out why exactly iterating over a path is broken. For some reason, a path data's header.type field is always nil, which causes cairo.Path:pairs() to return nil as its first result.

When I can't fix this, let's at least break it badly enough so that others will notice the problem, too. :-)
