### PR TITLE
Fix the mesh pattern tests

### DIFF
--- a/tests/cairo.lua
+++ b/tests/cairo.lua
@@ -178,7 +178,7 @@ function cairo.pattern_type()
    if cairo.version >= cairo.version_encode(1, 12, 0) then
       pattern = cairo.Pattern.create_mesh()
       check(cairo.MeshPattern:is_type_of(pattern))
-      check(cairo.GradientPattern:is_type_of(pattern))
+      check(not cairo.GradientPattern:is_type_of(pattern))
       check(cairo.Pattern:is_type_of(pattern))
       pattern = cairo.MeshPattern()
       check(cairo.MeshPattern:is_type_of(pattern))


### PR DESCRIPTION
Mesh patterns don't inherit from gradient patterns and thus this test failed.

I guess this means that you are using cairo 1.10 which is a good thing, so this works against that cairo version, too. :-)
