### PR TITLE
Unbreak loading of modules on OpenBSD (eg, libcairo.so.2)

### DIFF
--- a/lgi/core.c
+++ b/lgi/core.c
@@ -487,12 +487,18 @@ core_module (lua_State *L)
 {
   char *name;
 
-  /* If the version is present, combine it with basename. */
+  /* If the version is present, combine it with basename.
+     Except on OpenBSD, where libraries are versioned like libfoo.so.0.0
+     and we will always load the shared object with the highest version
+     number.
+   */
+#ifndef __OpenBSD__
   if (!lua_isnoneornil (L, 2))
     name = g_strdup_printf (MODULE_NAME_FORMAT_VERSION,
 			    luaL_checkstring (L, 1),
 			    (int) luaL_checkinteger (L, 2));
   else
+#endif
     name = g_strdup_printf (MODULE_NAME_FORMAT_PLAIN,
 			    luaL_checkstring (L, 1));
 


### PR DESCRIPTION
Libaries are named differently on OpenBSD. So instead of building up a filename, trying to open it, and fail as can be seen from this ktrace:

 14820 lua51    NAMI  "libcairo.so.2"
 14820 lua51    RET   stat -1 errno 2 No such file or directory
 14820 lua51    CALL  stat(0x621bfa2ebe0,0x7f7fffff9600)
 14820 lua51    NAMI  "libcairo.so.2.so"
 14820 lua51    RET   stat -1 errno 2 No such file or directory
 14820 lua51    CALL  stat(0x621bfa2e740,0x7f7fffff9600)
 14820 lua51    NAMI  "libcairo.so.2.la"
 14820 lua51    RET   stat -1 errno 2 No such file or directory

On OpenBSD one can just try to open libcairo.so and the loader will search for the library with the highest version (libcairo.so.12.0 in our case right now) and load that.

The attached patch fixes this on OpenBSD.
