### PR TITLE
Address the issue #34

### DIFF
--- a/lgi/Makefile
+++ b/lgi/Makefile
@@ -6,8 +6,9 @@
 #
 
 PREFIX = /usr/local
-LUA_LIBDIR = $(PREFIX)/lib/lua/5.1
-LUA_SHAREDIR = $(PREFIX)/share/lua/5.1
+LUA_VERSION=5.1
+LUA_LIBDIR = $(PREFIX)/lib/lua/$(LUA_VERSION)
+LUA_SHAREDIR = $(PREFIX)/share/lua/$(LUA_VERSION)
 
 GINAME = gobject-introspection-1.0
 PKGS = $(GINAME) gmodule-2.0 libffi


### PR DESCRIPTION
This adds an option to change the target building version easily so that
it would be easier to build against different lua versions.

Signed-off-by: Ignas Anikevicius (gns_ank) anikevicius@gmail.com
