### PR TITLE
Process abort when setting a record field with a callable

### DIFF
--- a/lgi/marshal.c
+++ b/lgi/marshal.c
@@ -717,7 +717,7 @@ marshal_2c_callable (lua_State *L, GICallableInfo *ci, GIArgInfo *ai,
 		     GICallableInfo *argci, void **args)
 {
   int nret = 0;
-  GIScopeType scope = g_arg_info_get_scope (ai);
+  GIScopeType scope = (ai == NULL) ? GI_SCOPE_TYPE_CALL : g_arg_info_get_scope (ai);
   gpointer user_data = NULL;
 
   /* Check 'nil' in optional case.  In this case, return NULL as


### PR DESCRIPTION
Note: I'm a total noob on GLib so I'm not sure if it is a bug or a misuse and even less if my fix is the most cleaver one !

I was playing with DBus APIs when I experienced process aborts while setting objects vtables. Here is a sample to reproduce the bug:

``` lua
lgi = require 'lgi'
Gio = lgi.require 'Gio'

vtable = Gio.DBusInterfaceVTable()
vtable.get_property = function() end
```

This code causes the following:

```
$ lua crash.lua 

** (process:19235): CRITICAL **: g_arg_info_get_scope: assertion `info != NULL' failed
**
Lgi:ERROR:marshal.c:758:marshal_2c_callable: assertion failed: (scope == GI_SCOPE_TYPE_ASYNC)
[1]    19235 abort (core dumped)  lua crash.lua
```

The provided fix seem to do the work and does not leak memory.
