### PR TITLE
Raise an exception if GTK+ initialization fails

### DIFF
--- a/lgi/override/Gtk.lua
+++ b/lgi/override/Gtk.lua
@@ -21,7 +21,7 @@ local log = lgi.log.domain('lgi.Gtk')
 
 -- Initialize GTK.
 Gtk.disable_setlocale()
-Gtk.init()
+assert(Gtk.init_check())
 
 -- Gtk.Allocation is just an alias to Gdk.Rectangle.
 Gtk.Allocation = Gdk.Rectangle


### PR DESCRIPTION
An error in gtk_init() resulted in a program termination not
interceptable on the Lua side. Unsetting the DISPLAY environment
variable on X11 based systems exhibits this issue:

$ DISPLAY= lua -e "print(pcall((require 'lgi').require, 'Gtk'))" 2> /dev/null
$

This is due to the exit() call present in gtk_init().

An assertion on gtk_init_check() instead can be properly intercepted.
This is the result on the previous command on my system after having
applied this patch:

$ DISPLAY= lua -e "print(pcall((require 'lgi').require, 'Gtk'))" 2> /dev/null
false   /usr/share/lua/5.2/lgi/override/Gtk.lua:24: assertion failed!
$
