### PR TITLE
Provide a fallback luaL_setfuncs() for Lua 5.1

### DIFF
--- a/lgi/Makefile
+++ b/lgi/Makefile
@@ -30,7 +30,7 @@ CCSHARED = -fPIC
 endif
 endif
 
-OBJS = buffer.o callable.o core.o gi.o marshal.o object.o record.o
+OBJS = buffer.o callable.o compat.o core.o gi.o marshal.o object.o record.o
 
 ifndef CFLAGS
 ifndef COPTFLAGS
@@ -64,6 +64,7 @@ $(VERSION_FILE) : Makefile ../Makefile
 
 buffer.o : buffer.c lgi.h $(DEPCHECK)
 callable.o : callable.c lgi.h $(DEPCHECK)
+compat.o : compat.c lgi.h $(DEPCHECK)
 core.o : core.c lgi.h $(DEPCHECK)
 gi.o : gi.c lgi.h $(DEPCHECK)
 marshal.o : marshal.c lgi.h $(DEPCHECK)

--- a/lgi/compat.c
+++ b/lgi/compat.c
@@ -1,0 +1,34 @@
+/*
+ * Dynamic Lua binding to GObject using dynamic gobject-introspection.
+ *
+ * Copyright (c) 2010, 2011, 2012 Pavel Holejsovsky
+ * Licensed under the MIT license:
+ * http://www.opensource.org/licenses/mit-license.php
+ *
+ * Compatibility layer for old Lua version.
+ */
+
+#include <string.h>
+#include "lgi.h"
+
+
+#if !defined LUA_VERSION_NUM || LUA_VERSION_NUM==501
+
+/* Adapted from
+   http://lua-users.org/wiki/CompatibilityWithLuaFive */
+void
+luaL_setfuncs (lua_State *L, const luaL_Reg *l, int nup)
+{
+  int i;
+  luaL_checkstack(L, nup, "too many upvalues");
+  for (; l->name != NULL; l++) {
+    for (i = 0; i < nup; i++)
+      lua_pushvalue(L, -nup);
+    lua_pushstring(L, l->name);
+    lua_pushcclosure(L, l->func, nup);
+    lua_settable(L, -(nup + 3));
+  }
+  lua_pop(L, nup);
+}
+
+#endif


### PR DESCRIPTION
The LGI bindings are failing at runtime because of the above missing
function. Added it to compat.c: implementation borrowed from Lua wiki.
