### PR TITLE
cairo: Fix a mistaken mask_surface signature

### DIFF
--- a/lgi/override/cairo.lua
+++ b/lgi/override/cairo.lua
@@ -242,7 +242,7 @@ for _, info in ipairs {
 			  { ti.double, dir = 'out' } },
 	 in_fill = { ret = ti.boolean, ti.double, ti.double },
 	 mask = { cairo.Pattern },
-	 mask_surface = { cairo.Pattern, ti.double, ti.double },
+	 mask_surface = { cairo.Surface, ti.double, ti.double },
 	 paint = {},
 	 paint_with_alpha = { ti.double },
 	 stroke = {},


### PR DESCRIPTION
This looks like a typo, as Cairo's API for mask_surface looks like this:

```
cairo_mask_surface(cairo_t *cr, cairo_surface_t *surface, double surface_x, double surface_y);
```
