### PR TITLE
Fix multiple state type registration

### DIFF
--- a/lgi/class.lua
+++ b/lgi/class.lua
@@ -347,9 +347,11 @@ function class.class_mt:derive(typename, ifaces)
       instance_init = instance_init_addr,
    }
 
+   -- Create the name to register with the GType system.
+   g_typename = typename:gsub('%.', '') .. core.id
+
    -- Register new type with GType system.
-   local gtype = register_static(self._gtype, typename:gsub('%.', ''),
-				 type_info, {})
+   local gtype = register_static(self._gtype, g_typename, type_info, {})
    rawset(new_class, '_gtype', core.gtype(gtype))
    if not new_class._gtype then
       error(("failed to derive `%s' from `%s'"):format(typename, self._name))


### PR DESCRIPTION
Issue #89 

If there are multiple states always append a state unique id of the form "+L%u". This has no affect on the first state, thus avoiding type name changes and a state is still prevented from registering the same type name multiple times.
