### PR TITLE
Support running LGI in strict mode

### DIFF
--- a/lgi/init.lua
+++ b/lgi/init.lua
@@ -11,7 +11,8 @@
 local assert, require, pcall, setmetatable, pairs, type, error, tostring,
 _VERSION, jit
    = assert, require, pcall, setmetatable, pairs, type, error, tostring,
-_VERSION, jit
+_VERSION, rawget(_G, 'jit')
+
 local package = require 'package'
 
 -- Require core lgi utilities, used during bootstrap.


### PR DESCRIPTION
Don't attempt to direclty access globals that might not
exist, instead use rawget().

Strict Mode:
http://metalua.luaforge.net/src/lib/strict.lua.html