### PR TITLE
Use PKG_CONFIG to find the pkg-config executable

### DIFF
--- a/lgi/Makefile
+++ b/lgi/Makefile
@@ -14,6 +14,10 @@ GINAME = gobject-introspection-1.0
 PKGS = $(GINAME) gmodule-2.0 libffi
 VERSION_FILE = version.lua
 
+ifndef PKG_CONFIG
+PKG_CONFIG=pkg-config
+endif
+
 ifneq ($(filter CYGWIN%, $(shell uname -s)),)
 CORE = corelgilua51.dll
 LIBFLAG = -shared
@@ -37,14 +41,14 @@ ifndef COPTFLAGS
 CFLAGS = -Wall -Wextra -O2 -g
 endif
 endif
-ALL_CFLAGS = $(CCSHARED) $(COPTFLAGS) $(LUA_CFLAGS) $(shell pkg-config --cflags $(PKGS)) $(CFLAGS)
-LIBS += $(shell pkg-config --libs $(PKGS))
+ALL_CFLAGS = $(CCSHARED) $(COPTFLAGS) $(LUA_CFLAGS) $(shell $(PKG_CONFIG) --cflags $(PKGS)) $(CFLAGS)
+LIBS += $(shell ${PKG_CONFIG} --libs $(PKGS))
 ALL_LDFLAGS = $(LIBFLAG) $(LDFLAGS)
 DEPCHECK = .depcheck
 
 # Precondition check
 $(DEPCHECK) : Makefile
-	pkg-config --exists '$(GINAME) >= 0.10.8' --print-errors
+	$(PKG_CONFIG) --exists '$(GINAME) >= 0.10.8' --print-errors
 	touch $@
 
 .PHONY : all clean install

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,19 +26,23 @@ endif
 PKGS = gio-2.0 cairo cairo-gobject gobject-introspection-1.0 gmodule-2.0 libffi
 LUA = lua
 
+ifndef PKG_CONFIG
+PKG_CONFIG=pkg-config
+endif
+
 ifndef CFLAGS
 ifndef COPTFLAGS
 CFLAGS = -Wall -g
 endif
 endif
-ALL_CFLAGS = $(CCSHARED) $(COPTFLAGS) $(LUA_CFLAGS) $(shell pkg-config --cflags $(PKGS)) $(CFLAGS) -I .
-LIBS += $(shell pkg-config --libs $(PKGS))
+ALL_CFLAGS = $(CCSHARED) $(COPTFLAGS) $(LUA_CFLAGS) $(shell $(PKG_CONFIG) --cflags $(PKGS)) $(CFLAGS) -I .
+LIBS += $(shell $(PKG_CONFIG) --libs $(PKGS))
 ALL_LDFLAGS = $(LIBFLAG) $(LDFLAGS)
 DEPCHECK = .depcheck
 
 # Precondition check
 $(DEPCHECK) : Makefile
-	pkg-config --exists '$(PKGS) >= 0.10.8' --print-errors
+	$(PKG_CONFIG) --exists '$(PKGS) >= 0.10.8' --print-errors
 	touch $@
 
 REGRESS = $(PFX)regress$(EXT)
@@ -61,7 +65,7 @@ check : all
 $(REGRESS) : regress.o
 	$(CC) $(ALL_LDFLAGS) -o $@ regress.o $(LIBS)
 
-GIDATADIR = $(shell pkg-config --variable=gidatadir gobject-introspection-1.0)/tests
+GIDATADIR = $(shell $(PKG_CONFIG) --variable=gidatadir gobject-introspection-1.0)/tests
 
 regress.o : $(GIDATADIR)/regress.c $(GIDATADIR)/regress.h $(DEPCHECK)
 	$(CC) $(ALL_CFLAGS) -c -o $@ $<


### PR DESCRIPTION
Instead of hard-coding pkg-config use the $PKG_CONFIG environment
variable to allow setting another pkg-config executable. This is
particularly important when cross-compiling or on mulitarch layouts
where pkg-config may be prefixed with the target architecture.