### PR TITLE
Do not copy version.lua twice

### DIFF
--- a/lgi/Makefile
+++ b/lgi/Makefile
@@ -81,6 +81,6 @@ install : $(CORE) $(VERSION_FILE)
 	mkdir -p $(DESTDIR)$(LUA_SHAREDIR)
 	cp ../lgi.lua $(DESTDIR)$(LUA_SHAREDIR)
 	mkdir -p $(DESTDIR)$(LUA_SHAREDIR)/lgi
-	cp $(CORESOURCES) $(VERSION_FILE) $(DESTDIR)$(LUA_SHAREDIR)/lgi
+	cp $(CORESOURCES) $(DESTDIR)$(LUA_SHAREDIR)/lgi
 	mkdir -p $(DESTDIR)$(LUA_SHAREDIR)/lgi/override
 	cp $(OVERRIDES) $(DESTDIR)$(LUA_SHAREDIR)/lgi/override


### PR DESCRIPTION
version.lua is specified twice during the copy: one in VERSION_FILE and
one in CORESOURCES (make uses lazy evaluation so CORESOURCES is expanded
only when used, i.e. during the copy).