### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ providing ideas, spreading a word...  *Many thanks to all of you!*
  - Avoid unexpected dependency on cairo-devel, cairo-runtime is now
    enough
  - Make `set_resident()` more robust and fix stack leak for Lua 5.2 case,
-   avoid useless warning when `set_resident()` fails (to accomodate for
+   avoid useless warning when `set_resident()` fails (to accommodate for
    static linking case).
  - Fix small memory leak (mutex) which occured once per opened
    `lua_State` using lgi.


### PR DESCRIPTION
pavouk, I've corrected a typographical error in the documentation of the [lgi](https://github.com/pavouk/lgi) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.