### PR TITLE
Tweaks for the build on Mac OS X

### DIFF
--- a/lgi/Makefile
+++ b/lgi/Makefile
@@ -25,6 +25,7 @@ ifeq ($(HOST_OS),darwin)
 CORE = corelgilua51.so
 LIBFLAG = -bundle -undefined dynamic_lookup
 CCSHARED = -fno-common
+GOBJECT_INTROSPECTION_LIBDIR = $(shell pkg-config --variable=libdir $(GINAME))
 else
 CORE = corelgilua51.so
 LIBFLAG = -shared
@@ -38,6 +39,9 @@ ifndef CFLAGS
 ifndef COPTFLAGS
 CFLAGS = -Wall -Wextra -O2 -g
 endif
+endif
+ifeq ($(HOST_OS),darwin)
+CFLAGS += -DGOBJECT_INTROSPECTION_LIBDIR=\"$(GOBJECT_INTROSPECTION_LIBDIR)\"
 endif
 ALL_CFLAGS = $(CCSHARED) $(COPTFLAGS) $(LUA_CFLAGS) $(shell $(PKG_CONFIG) --cflags $(PKGS)) $(CFLAGS)
 LIBS += $(shell $(PKG_CONFIG) --libs $(PKGS))

--- a/lgi/core.c
+++ b/lgi/core.c
@@ -536,6 +536,13 @@ core_module (lua_State *L)
     name = g_strdup_printf (MODULE_NAME_FORMAT_PLAIN,
 			    luaL_checkstring (L, 1));
 
+#if defined(__APPLE__)
+  char *path = g_module_build_path (GOBJECT_INTROSPECTION_LIBDIR,
+                                    name);
+  g_free(name);
+  name = path;
+#endif
+
   /* Try to load the module. */
   GModule *module = g_module_open (name, 0);
   if (module == NULL)


### PR DESCRIPTION
On Mac OS X, the `file_name` parameter of `g_module_open()` must be an
abosolute path to open the module successfully.

To fulfil the requirement, the following changes were done:

 * `lgi/Makefile`
  - Add a new variable called `GOBJECT_INTROSPECTION_LIBDIR` whose value
    is set by `pkgconfig` automatically.
  - Pass the value of the variable to the compiler as a CPP constant
    macro via `CFLAGS`.

 * `lgi/core.c`
   - Construct the absolute path of a module using the value of
     `GOBJECT_INTROSPECTION_LIBDIR`.