### PR TITLE
record.load: Require constructor to be a function

### DIFF
--- a/lgi/record.lua
+++ b/lgi/record.lua
@@ -199,7 +199,8 @@ function record.load(info)
 
    -- Check, whether ctor is valid.  In order to be valid, it must
    -- return instance of this record.
-   if (ctor and ctor.return_type.tag =='interface'
+   if (ctor and ctor.type == 'function'
+       and ctor.return_type.tag =='interface'
        and ctor.return_type.interface == info) then
       ctor = core.callable.new(ctor)
       record._new = function(typetable, ...) return ctor(...) end


### PR DESCRIPTION
libgtop (available at https://github.com/GNOME/libgtop/commits/master) has a
struct glibtop_cpu. While trying to load this through e.g.
require("lgi").GTop.glibtop_cpu, the following error occurred:

  lgi/record.lua:153: attempt to index a nil value (field 'return_type')

This occurred because the code tried to find a constructor for this struct and
for this it "un-camel-cased" the struct name, which didn't change anything,
because the struct name isn't camel-cased, and then assumed that the result were
information about a function. However, this just found the struct again.

Fix this by explicitly testing if the type of the result is a function.

Signed-off-by: Uli Schlachter <uli.schlachter@informatik.uni-oldenburg.de>

(No unit test because I don't know how and if this is wrong/stupid, feel free to take this as a bug report and fix it yourself however you like.)