### PR TITLE
Make it possible to detect EOF on a GDataInputstream

### DIFF
--- a/lgi/marshal.c
+++ b/lgi/marshal.c
@@ -501,7 +501,10 @@ marshal_2lua_array (lua_State *L, GITypeInfo *ti, GIDirection dir,
       /* UINT8 arrays are marshalled as Lua strings. */
       if (len < 0)
 	len = data ? strlen(data) : 0;
-      lua_pushlstring (L, data, len);
+      if (data != NULL || len != 0)
+        lua_pushlstring (L, data, len);
+      else
+        lua_pushnil (L);
     }
   else
     {

--- a/tests/gio.lua
+++ b/tests/gio.lua
@@ -1,0 +1,39 @@
+--[[--------------------------------------------------------------------------
+
+  LGI testsuite, GIo test suite.
+
+  Copyright (c) 2016 Uli Schlachter
+  Licensed under the MIT license:
+  http://www.opensource.org/licenses/mit-license.php
+
+--]]--------------------------------------------------------------------------
+
+local lgi = require 'lgi'
+local core = require 'lgi.core'
+
+local check = testsuite.check
+local checkv = testsuite.checkv
+
+local gio = testsuite.group.new('gio')
+
+function gio.read()
+    local GLib, Gio = lgi.GLib, lgi.Gio
+
+    -- Prepare the input to read
+    local input
+    input = "line"
+    input = Gio.MemoryInputStream.new_from_data(input)
+    input = Gio.DataInputStream.new(input)
+
+    local line, length
+
+    -- Read line
+    line, length = input:read_line()
+    checkv(line, "line", "string")
+    checkv(length, 4, "number")
+
+    -- Read EOF
+    line, length = input:read_line()
+    checkv(line, nil, "nil")
+    checkv(length, 0, "number")
+end

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -117,6 +117,7 @@ for _, sourcefile in ipairs {
    'gtk.lua',
    'cairo.lua',
    'pango.lua',
+   'gio.lua',
 } do
    dofile(testpath .. '/' .. sourcefile)
 end


### PR DESCRIPTION
The C-API will return a NULL-pointer when the end of the input is reached. However, `lua_pushstring` and `lua_pushlstring` turn NULL-pointers into empty strings and so end-of-file became indistinguishable from an empty line in Lua. Fix this by marshalling a NULL "string" pointer (actually: UINT8 array) as `nil`.

This fixes https://github.com/pavouk/lgi/issues/125.

Feel free to replace this with a better fix or tell me what I did wrong.