### PR TITLE
Don't hard-code the pkg-config executable

### DIFF
--- a/lgi/Makefile
+++ b/lgi/Makefile
@@ -25,7 +25,7 @@ ifeq ($(HOST_OS),darwin)
 CORE = corelgilua51.so
 LIBFLAG = -bundle -undefined dynamic_lookup
 CCSHARED = -fno-common
-GOBJECT_INTROSPECTION_LIBDIR = $(shell pkg-config --variable=libdir $(GINAME))
+GOBJECT_INTROSPECTION_LIBDIR = $(shell $(PKG_CONFIG) --variable=libdir $(GINAME))
 else
 CORE = corelgilua51.so
 LIBFLAG = -shared


### PR DESCRIPTION
eb1b930892da75135a1af6e377a3ebe27db76b85 already introduced a PKG_CONFIG variable, so use it instead of hard-coding "pkg-config".