### PR TITLE
Fix crash due to Gio.DBusProxy.get_interface_info

### DIFF
--- a/lgi/override/Gio-DBus.lua
+++ b/lgi/override/Gio-DBus.lua
@@ -69,3 +69,14 @@ function Gio.DBusNodeInfo._attribute:xml()
    self:generate_xml(0, xml)
    return xml.str
 end
+
+-- g_dbus_proxy_get_interface_info() is documented as "Do not unref the returned
+-- object", but has transfer=full. Fix this.
+if core.gi.Gio.DBusProxy.methods.get_interface_info.return_transfer ~= 'none' then
+   Gio.DBusProxy.get_interface_info = core.callable.new {
+      addr = core.gi.Gio.resolve.g_dbus_proxy_get_interface_info,
+      name = 'DBusProxy.get_interface_info',
+      ret = Gio.DBusInterfaceInfo,
+      core.gi.Gio.DBusProxy.methods.new_sync.return_type,
+   }
+end

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -57,8 +57,8 @@ clean :
 check : all
 	cd .. && LD_LIBRARY_PATH=tests:$$LD_LIBRARY_PATH \
 	    GI_TYPELIB_PATH=tests:$$GI_TYPELIB_PATH \
-	    LUA_PATH=./?.lua\;`$(LUA) -e "print(package.path)"` \
-	    LUA_CPATH=./?.so\;`$(LUA) -e "print(package.cpath)"` \
+	    LUA_PATH="./?.lua;${LUA_PATH};" \
+	    LUA_CPATH="./?.so;${LUA_CPATH};" \
 	    $(LUA) tests/test.lua
 
 $(REGRESS) : regress.o

--- a/tests/dbus.lua
+++ b/tests/dbus.lua
@@ -122,3 +122,31 @@ function dbus.info_xml()
    check(node.interfaces[1].properties[1].flags.READABLE)
    check(node.interfaces[1].properties[1].flags.WRITABLE)
 end
+
+function dbus.proxy_get_interface_info()
+   local Gio = lgi.Gio
+
+   -- This test does not actually test much, it only checks for a double-free due
+   -- to a wrong annotation on GDBusProxy's get_interface_info()
+   local test_bus = Gio.TestDBus.new(Gio.TestDBusFlags.NONE)
+   test_bus:up()
+
+   do
+      local interface = Gio.DBusInterfaceInfo {
+         name = 'SomeInterface'
+      }
+      local bus = Gio.bus_get_sync(Gio.BusType.SESSION)
+      local proxy, err = Gio.DBusProxy.new_sync(bus, Gio.DBusProxyFlags.NONE, interface, "org.foo", "/", "org.foo.SomeInterface", nil)
+      assert(proxy, err)
+
+      local interface2 = proxy:get_interface_info()
+
+      -- Just so that we do test something
+      assert(interface == interface2)
+   end
+
+   -- Make sure the above-created objects are collected before the bus
+   collectgarbage("collect")
+
+   test_bus:down()
+end


### PR DESCRIPTION
I think that this should fix #88, but I'm not completely sure. Feel free to cherry-pick only parts of this (e.g. if you don't like the unit test). Also, feel free to tell me what needs to be changed. :-)

@Elv13 Could you check if this fixes the crashes that you saw with wirefu?

Edit: Important point: I only tested this with Lua 5.3. This might be important for the first commit. Should I try setting up travis-ci.org for lgi and writing a `.travis.yml` as a separate pull request?
