### PR TITLE
Add Lua 5.3 compatibility to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ license, see LICENSE file for full text.
 
 Home of the project is on [GitHub](http://github.com/pavouk/lgi).
 
-LGI is tested and compatible with standard Lua 5.1, Lua 5.2 and
+LGI is tested and compatible with standard Lua 5.1, Lua 5.2, Lua 5.3 and
 LuaJIT2.  Compatibility with other Lua implementations is not tested
 yet.
 


### PR DESCRIPTION
In the [changelog for 0.9.1](https://github.com/pavouk/lgi#091-27-may-2016) full Lua 5.3 compatibility is stated so I took the liberty of adding this to the README.