### PR TITLE
.travis.yml: Fix Lua download link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - |
     set -ev
     if [[ "$LUA" == "5.3" ]]; then
-      travis_retry wget https://github.com/lua/lua/releases/download/5.3.3/lua-5.3.3.tar.gz -O lua.tar.gz
+      travis_retry wget http://www.lua.org/ftp/lua-5.3.3.tar.gz -O lua.tar.gz
       tar -xvzf lua.tar.gz
       (cd lua-5.3.3/src \
         && make SYSCFLAGS="-DLUA_USE_LINUX -ULUA_COMPAT_5_2 -DLUA_USE_APICHECK" SYSLIBS="-Wl,-E -ldl -lreadline" LUA_A=liblua.so MYCFLAGS="-fPIC" RANLIB=: AR="gcc -shared -ldl -o" liblua.so \


### PR DESCRIPTION
The unofficial GitHub mirror became a bit more official and
removed/changed releases. Switch to the official Lua site instead.

Signed-off-by: Uli Schlachter <psychon@znc.in>

The Travis build for #152 failed. This fixes things (hopefully).