### PR TITLE
DBusCallFlags are needed in method calls

### DIFF
--- a/samples/GDbus/list-system-services.lua
+++ b/samples/GDbus/list-system-services.lua
@@ -87,7 +87,7 @@ local Gio = lgi.require 'Gio'
       'ListNames',
       nil,
       nil,
-      Gio.DBusConnectionFlags.NONE,
+      Gio.DBusCallFlags.NONE,
       -1)
    -- We know that ListNames returns '(as)'
    local services = var[1].value


### PR DESCRIPTION
Caught this while trying to tame lgi.