### PR TITLE
Add support for indexing Gtk.TreeStore and Gtk.ListStore with nums or strs

### DIFF
--- a/docs/gtk.md
+++ b/docs/gtk.md
@@ -265,6 +265,13 @@ creation section of previous example can be simplified to:
        [PersonColumn.EMPLOYEE] = true,
     }
 
+Note that you also can use numbers or strings as indexes. Useful
+example is reading values selected from `Gtk.ComboBox`:
+
+    local index = MyComboBox:get_active() -- Index is string, but numbers is also supported
+    print("Active index: ", index)
+    print("Selected value: ", MyStore[index])
+
 Note that while the example uses `Gtk.ListStore`, similar overrides
 are provided also for `Gtk.TreeStore`.
 

--- a/lgi/override/Gtk.lua
+++ b/lgi/override/Gtk.lua
@@ -310,7 +310,11 @@ function Gtk.TreeModel:_element(model, key, origin)
    elseif Gtk.TreePath:is_type_of(key) then
       return model:get_iter(key), '_iter'
    end
-   return tree_model_element(self, model, key, origin)
+   local natres = {tree_model_element(self, model, key, origin)}
+   if #natres > 0 then return unpack(natres) end
+   if model ~= nil and (type(key) == 'number' or type(key) == 'string') then
+      return model:get_iter(Gtk.TreePath.new_from_string(key)), '_iter'
+   end
 end
 function Gtk.TreeModel:_access_iter(model, iter, ...)
    if select('#', ...) > 0 then

--- a/lgi/override/Gtk.lua
+++ b/lgi/override/Gtk.lua
@@ -9,7 +9,7 @@
 ------------------------------------------------------------------------------
 
 local select, type, pairs, ipairs, unpack, setmetatable, error, next, rawget
-   = select, type, pairs, ipairs, unpack, setmetatable, error, next, rawget
+   = select, type, pairs, ipairs, unpack or table.unpack, setmetatable, error, next, rawget
 local lgi = require 'lgi'
 local core = require 'lgi.core'
 local Gtk = lgi.Gtk


### PR DESCRIPTION
This patch enables indexing Gtk.TreeStore and Gtk.ListStore with numbers (e. g. `liststore[0]`) or strings (e.g. `treestore["1:2"]`). Usefull example: you got string from GtkComboBox, and want to give value from its ListStore, then it will be so easy:

    local active = MyComboBox:get_active()
    local row = MyListStore[active]
Should I provide tests for this feature?