### PR TITLE
Make objects unusable in the __gc metamethod

### DIFF
--- a/lgi/callable.c
+++ b/lgi/callable.c
@@ -651,6 +651,10 @@ callable_gc (lua_State *L)
     callable_param_destroy (&callable->params[i]);
 
   callable_param_destroy (&callable->retval );
+
+  /* Unset the metatable / make the callable unusable */
+  lua_pushnil (L);
+  lua_setmetatable (L, 1);
   return 0;
 }
 

--- a/lgi/core.c
+++ b/lgi/core.c
@@ -481,6 +481,10 @@ module_gc (lua_State *L)
 {
   GModule **module = luaL_checkudata (L, 1, UD_MODULE);
   g_module_close (*module);
+
+  /* Unset the metatable / make the module unusable */
+  lua_pushnil (L);
+  lua_setmetatable (L, 1);
   return 0;
 }
 

--- a/lgi/gi.c
+++ b/lgi/gi.c
@@ -109,6 +109,10 @@ infos_gc (lua_State *L)
 {
   Infos *infos = luaL_checkudata (L, 1, LGI_GI_INFOS);
   g_base_info_unref (infos->info);
+
+  /* Unset the metatable / make the infos unusable */
+  lua_pushnil (L);
+  lua_setmetatable (L, 1);
   return 0;
 }
 

--- a/lgi/object.c
+++ b/lgi/object.c
@@ -266,6 +266,10 @@ static int
 object_gc (lua_State *L)
 {
   object_unref (L, object_get (L, 1));
+
+  /* Unset the metatable / make the object unusable */
+  lua_pushnil (L);
+  lua_setmetatable (L, 1);
   return 0;
 }
 

--- a/lgi/record.c
+++ b/lgi/record.c
@@ -445,6 +445,9 @@ record_gc (lua_State *L)
       lua_rawset (L, LUA_REGISTRYINDEX);
     }
 
+  /* Unset the metatable / make the record unusable */
+  lua_pushnil (L);
+  lua_setmetatable (L, 1);
   return 0;
 }
 


### PR DESCRIPTION
Fixes: https://github.com/pavouk/lgi/issues/122
Signed-off-by: Uli Schlachter <uli.schlachter@informatik.uni-oldenburg.de>

I tried to come up with a test case for this, but failed. So far I only managed to make valgrind complain about a use-after-free, but I haven't actually managed to cause a crash (and even less: reproducably so).