### PR TITLE
Better error message when Gtk.init_check() fails

### DIFF
--- a/lgi/namespace.lua
+++ b/lgi/namespace.lua
@@ -183,6 +183,11 @@ function namespace.require(name, version)
 	    require(override_name)
 	 end
       end
+      if ok and type(msg) == "string" then
+	  -- It's an error message for something that does not want to be
+	  -- re-loaded, see e.g. the call to Gtk.init_check() in Gtk.lua.
+	  error(msg)
+      end
    end
    return ns
 end

--- a/lgi/override/Gtk.lua
+++ b/lgi/override/Gtk.lua
@@ -21,7 +21,9 @@ local log = lgi.log.domain('lgi.Gtk')
 
 -- Initialize GTK.
 Gtk.disable_setlocale()
-assert(Gtk.init_check())
+if not Gtk.init_check() then
+    return "gtk_init_check() failed"
+end
 
 -- Gtk.Allocation is just an alias to Gdk.Rectangle.
 Gtk.Allocation = Gdk.Rectangle


### PR DESCRIPTION
When loading a namespace, namespace.require() also loads the suitable
override file. When no override file exists, this should be non-fatal,
so pcall(require, override_name) is used. However, any other errors
besides "no such file" should still be fatal. Thus, in this case
namespace.require() require()s the override file again expecting it to
fail in the same way again, but this time the error is propagated out.

This behaviour causes problems for Gtk when gtk_init_check() fails.
Since gtk was already (unsuccessfully) initialized when the override
file was loaded the first time, the call to gtk_disable_setlocale() that
is done first results in a warning "gtk_disable_setlocale() must be
called before gtk_init()" to be printed by Gtk. Also, the actual error
message will be "assertion failed!", which does not say much. So, it is
quite natural to hunt after the extraneous call to gtk_init(), which is
not really the problem here.

To get a better error message and to get rid of the extra call to
gtk_disable_setlocale(), this commit adds a new convention: When an
override file returns a string, that's an error message. In this case
the override file is not loaded a second call and instead
namespace.require() calls error() with the given error message.

This results in a more obvious error message without any "red herring"
messages which are misleading. However, one downside is that the
traceback that is printed now just points at namespace.require() calling
error(), instead to where the error actually happened. However, since we
control override files and I expect that this new facility will not be
used much, it will still be simple to find the source of the error: Just
grep for the error message.

Fixes: https://github.com/pavouk/lgi/issues/169
Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @TingPing 
This time I even tested the patch. :-)
Compared to the version I proposed yesterday, this now has an extra `ok and` in the `if`-condition. Without this, this `if` would wrongly trigger when an override file is not found / does not exist.