### PR TITLE
Traivs: Check that lgi works after 'make install'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,4 +56,5 @@ script:
   - xvfb-run make check LUA_CFLAGS="-I$LUAINCLUDE"
 
   # Just to also check make install
-  - sudo make install
+  - sudo make install LUA_VERSION="$LUA"
+  - xvfb-run lua -e 'Gtk = require("lgi").Gtk  c = Gtk.Grid()  w = Gtk.Label()  c:add(w)  assert(w.parent == c)  a, b = dofile("lgi/version.lua"), require("lgi.version")  assert(a == b, string.format("%s == %s", a, b))'


### PR DESCRIPTION
This is WIP since I am quite sure that this new check fails. `make install` only picks the right installation dir for Lua 5.1, I bet.
I will remove the WIP from the title once this is done and works