### PR TITLE
Work around API break in GLib 2.54

### DIFF
--- a/lgi/override/GObject-Object.lua
+++ b/lgi/override/GObject-Object.lua
@@ -38,7 +38,10 @@ end
 -- Object constructor, 'param' contains table _with properties/signals
 -- to initialize.
 local parameter_repo = repo.GObject.Parameter
-local object_new = gi.GObject.Object.methods.new
+-- Before GLib 2.54, g_object_newv() was annotated with [rename-to g_object_new].
+-- Starting from GLib 2.54, g_object_new_with_properties() has this annotation.
+-- We always want g_object_newv().
+local object_new = gi.GObject.Object.methods.newv or gi.GObject.Object.methods.new
 if object_new then
    object_new = core.callable.new(object_new)
 else


### PR DESCRIPTION
Previously, g_object_newv() was annotated with [rename-to g_object_new].
This annotation was moved to (the new function)
g_object_new_with_properties(). Since this expects different arguments,
things break. Work around this by using g_object_newv() directly if it
exists.

Fixes: https://github.com/pavouk/lgi/issues/167
Signed-off-by: Uli Schlachter <psychon@znc.in>

@TingPing Please test this with a newer GLib which would be broken without this patch.