### PR TITLE
Run tests in a proper DBus session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   # Install build dependencies
   - travis_retry sudo apt-get install -y libgirepository1.0-dev libcairo2-dev gir1.2-gtk-3.0 libffi-dev libglib2.0-dev
   # And dependencies for running tests
-  - travis_retry sudo apt-get install -y xvfb
+  - travis_retry sudo apt-get install -y xvfb dbus-x11
 
   # Install Lua (per env).
   # Note that Lua 5.3 is installed manually, because it is not available in Ubuntu Trusty.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -59,7 +59,7 @@ check : all
 	    GI_TYPELIB_PATH=tests:$$GI_TYPELIB_PATH \
 	    LUA_PATH="./?.lua;${LUA_PATH};" \
 	    LUA_CPATH="./?.so;${LUA_CPATH};" \
-	    $(LUA) tests/test.lua
+	    $(shell command -v dbus-run-session || echo /usr/bin/dbus-launch) $(LUA) tests/test.lua
 
 $(REGRESS) : regress.o
 	$(CC) $(ALL_LDFLAGS) -o $@ regress.o $(LIBS)

--- a/tests/dbus.lua
+++ b/tests/dbus.lua
@@ -126,27 +126,15 @@ end
 function dbus.proxy_get_interface_info()
    local Gio = lgi.Gio
 
-   -- This test does not actually test much, it only checks for a double-free due
-   -- to a wrong annotation on GDBusProxy's get_interface_info()
-   local test_bus = Gio.TestDBus.new(Gio.TestDBusFlags.NONE)
-   test_bus:up()
+   local interface = Gio.DBusInterfaceInfo {
+      name = 'SomeInterface'
+   }
+   local bus = Gio.bus_get_sync(Gio.BusType.SESSION)
+   local proxy, err = Gio.DBusProxy.new_sync(bus, Gio.DBusProxyFlags.NONE, interface, "org.foo", "/", "org.foo.SomeInterface", nil)
+   assert(proxy, err)
 
-   do
-      local interface = Gio.DBusInterfaceInfo {
-         name = 'SomeInterface'
-      }
-      local bus = Gio.bus_get_sync(Gio.BusType.SESSION)
-      local proxy, err = Gio.DBusProxy.new_sync(bus, Gio.DBusProxyFlags.NONE, interface, "org.foo", "/", "org.foo.SomeInterface", nil)
-      assert(proxy, err)
+   local interface2 = proxy:get_interface_info()
 
-      local interface2 = proxy:get_interface_info()
-
-      -- Just so that we do test something
-      assert(interface == interface2)
-   end
-
-   -- Make sure the above-created objects are collected before the bus
-   collectgarbage("collect")
-
-   test_bus:down()
+   -- Just so that we do test something
+   assert(interface == interface2)
 end

--- a/tests/gio.lua
+++ b/tests/gio.lua
@@ -64,13 +64,10 @@ function gio.async_access()
    check(res ~= nil)
 
    local b = Gio.Async.call(function()
-			       return Gio.async_bus_get('SYSTEM')
+			       return Gio.async_bus_get('SESSION')
    end)()
    check(Gio.DBusConnection:is_type_of(b))
 
-   -- Disable randomly crashing test until issue with random dbus
-   -- crashes is resolved.
-   if false then
    local proxy = Gio.Async.call(function(bus)
 				   return Gio.DBusProxy.async_new(
 				      bus, 'NONE', nil,
@@ -79,6 +76,5 @@ function gio.async_access()
 				      'org.freedesktop.DBus')
    end)(b)
    check(Gio.DBusProxy:is_type_of(proxy))
-   end
 end
 

--- a/tests/gio.lua
+++ b/tests/gio.lua
@@ -41,6 +41,11 @@ function gio.read()
 end
 
 function gio.async_access()
+   -- Sometimes this hangs with LuaJIT when the JIT is on, no idea why.
+   -- FIXME: Figure out what is going on and fix this.
+   -- See also https://github.com/LuaJIT/LuaJIT/issues/340.
+   if jit then jit.off() end
+
    local Gio = lgi.Gio
    local res
 
@@ -76,5 +81,7 @@ function gio.async_access()
 				      'org.freedesktop.DBus')
    end)(b)
    check(Gio.DBusProxy:is_type_of(proxy))
+
+   if jit then jit.on() end
 end
 


### PR DESCRIPTION
This makes tests/Makefile run the tests under "dbus-run-session" so that
a DBus user session surely exists. Thus, the code using Gio.TestDBus is
no longer necessary and can be removed.

Signed-off-by: Uli Schlachter <psychon@znc.in>