### PR TITLE
Replace busy loop with usleep call

### DIFF
--- a/tests/glib.lua
+++ b/tests/glib.lua
@@ -34,7 +34,7 @@ function glib.timer()
    check(type(el1) == 'number')
    check(type(ms1) == 'number')
 
-   for i = 1, 1000000 do end
+   lgi.GLib.usleep(1000) -- wait one millisecond
 
    local el2, ms2 = timer:elapsed()
    check(el1 < el2)


### PR DESCRIPTION
tests/glib.lua counts to one million in an attempt to spend some time so
that it can test that GLib's Timer correctly nootices that some
timepassed. The "count to one million"-loop needs about three
milliseconds here with Lua 5.2. LuaJIT is likely faster than this.

Instead of relying on this loop being slow enough, replace it with a
call to g_usleep to sleep for a millisecond.

Signed-off-by: Uli Schlachter <psychon@znc.in>