### PR TITLE
callable: Fix enum return from C functions

### DIFF
--- a/lgi/callable.c
+++ b/lgi/callable.c
@@ -769,7 +769,7 @@ callable_param_2lua (lua_State *L, Param *param, GIArgument *arg,
 			  args + callable->has_self);
       else
 	{
-	  union { GIArgument arg; int i; } *u = (gpointer) arg;
+	  union { GIArgument arg; ffi_sarg i; } *u = (gpointer) arg;
 	  lua_pushnumber (L, u->i);
 	}
     }


### PR DESCRIPTION
According to [1], return values smaller than sizeof(long) are returned
as ffi_arg or ffi_sarg. Thus, the code here needs to use ffi_sarg
instead of int to work correctly.

This fixes a test failure on s390x that boils down to
cairo_pattern_get_type() returning 2, but the C code here turns that
into a value of 0.

A big "thank" you to Debian and specifically to Mattia Rizzolo for
giving me access to a porterbox so that I could debug this myself.

[1]: https://linux.die.net/man/3/ffi_call

Signed-off-by: Uli Schlachter <psychon@znc.in>