### PR TITLE
Use marshalling thread2

### DIFF
--- a/tests/gio.lua
+++ b/tests/gio.lua
@@ -41,11 +41,6 @@ function gio.read()
 end
 
 function gio.async_access()
-   -- Sometimes this hangs with LuaJIT when the JIT is on, no idea why.
-   -- FIXME: Figure out what is going on and fix this.
-   -- See also https://github.com/LuaJIT/LuaJIT/issues/340.
-   if jit then jit.off() end
-
    local Gio = lgi.Gio
    local res
 
@@ -81,7 +76,5 @@ function gio.async_access()
 				      'org.freedesktop.DBus')
    end)(b)
    check(Gio.DBusProxy:is_type_of(proxy))
-
-   if jit then jit.on() end
 end
 


### PR DESCRIPTION
Sorry for the spam, but here is a new attempt following up on #181 and #183. This time I first did some refactoring to keep "the actual change" small. Now, errors during marshalling are still thrown on the original thread/coroutine when possible.