### PR TITLE
cairo: Use the typelib before loading cairo directly

### DIFF
--- a/lgi/override/cairo.lua
+++ b/lgi/override/cairo.lua
@@ -20,17 +20,7 @@ local record = require 'lgi.record'
 local enum = require 'lgi.enum'
 local ti = ffi.types
 
-cairo._module = core.module('cairo', 2)
 local module_gobject = core.gi.cairo.resolve
-
--- Versioning support.
-function cairo.version_encode(major, minor, micro)
-   return 10000 * major + 100 * minor + micro
-end
-cairo.version = core.callable.new {
-   addr = cairo._module.cairo_version, ret = ti.int } ()
-cairo.version_string = core.callable.new {
-   addr = cairo._module.cairo_version_string, ret = ti.utf8 } ()
 
 -- Load some constants.
 cairo._constant = {
@@ -57,6 +47,18 @@ for _, name in pairs {
       cairo._enum[name] = component.create(nil, enum.enum_mt, 'cairo.' .. name)
    end
 end
+
+-- Load libcairo.so directly; this has to happen after the typelib was used
+cairo._module = core.module('cairo', 2)
+
+-- Versioning support.
+function cairo.version_encode(major, minor, micro)
+   return 10000 * major + 100 * minor + micro
+end
+cairo.version = core.callable.new {
+   addr = cairo._module.cairo_version, ret = ti.int } ()
+cairo.version_string = core.callable.new {
+   addr = cairo._module.cairo_version_string, ret = ti.utf8 } ()
 
 -- Load definitions of all boxed records.
 cairo._struct = cairo._struct or {}


### PR DESCRIPTION
Doing core.module('cairo', 2) results in dlopen("libcairo.so.2"). This
causes a problem in NixOS since there is no single, global library
search path and instead absolute paths to libraries are inserted during
build. Thus, loading the library fails.

However, in NixOS the cairo-1.0.typelib is patched to contain a full
path to libcairo.so.2. Thus, when causing this library to be loaded
through gobject-introspection, everything works out.

To achieve this goal, this commit reorders some code in the cairo
override file so that first some enums are loaded through
gobject-introspection (causing libcairo.so to be loaded) and only
afterwards cairo is opened directly (which does not need a search path
since cairo was already loaded before).

Related to: https://github.com/NixOS/nixpkgs/pull/34584
Signed-off-by: Uli Schlachter <psychon@znc.in>