### PR TITLE
Add meson build system support

### DIFF
--- a/lgi/meson.build
+++ b/lgi/meson.build
@@ -1,0 +1,45 @@
+liblgi = shared_module('corelgilua51',
+  sources: [
+    'buffer.c',
+    'callable.c',
+    'core.c',
+    'gi.c',
+    'marshal.c',
+    'object.c',
+    'record.c',
+  ],
+  dependencies: [
+    lua_dep,
+    gi_dep,
+    dependency('libffi'),
+    dependency('gmodule-2.0'),
+  ],
+  name_prefix: '',
+  install: true,
+  install_dir: join_paths(lua_cpath, 'lgi'),
+)
+
+install_data([
+  'class.lua',
+  'component.lua',
+  'core.lua',
+  'enum.lua',
+  'ffi.lua',
+  'init.lua',
+  'log.lua',
+  'namespace.lua',
+  'package.lua',
+  'record.lua'
+], install_dir: join_paths(lua_path, 'lgi'))
+
+install_subdir('override', install_dir: join_paths(lua_path, 'lgi'))
+
+conf = configuration_data()
+conf.set('VERSION', meson.project_version())
+configure_file(
+  input: 'version.lua.in',
+  output: 'version.lua',
+  configuration: conf,
+  install: true,
+  install_dir: join_paths(lua_path, 'lgi'),
+)

--- a/lgi/version.lua.in
+++ b/lgi/version.lua.in
@@ -1,0 +1,1 @@
+return '@VERSION@'

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,70 @@
+project('lgi', 'c',
+  version: '0.9.2',
+  meson_version: '>= 0.44.0',
+  default_options: [
+    'warning_level=2',
+    'buildtype=debugoptimized',
+  ],
+)
+
+lua_possible_names = [
+  'lua',
+  'lua5.3', 'lua53',
+  'lua5.2', 'lua52',
+  'lua5.1', 'lua51',
+  'luajit'
+]
+
+lua_bin = get_option('lua-bin')
+lua_name = get_option('lua-pc')
+
+if lua_name == 'auto'
+  lua_found = false
+
+  foreach name : lua_possible_names
+    if not lua_found
+      lua_dep = dependency(name, required: false)
+      lua_found = lua_dep.found()
+      lua_name = name
+    endif
+  endforeach
+
+  if not lua_found
+    error('Failed to find lua pkg-config file, you can specify it manually with `-Dlua-pc=lua54`')
+  endif
+
+  if lua_bin == 'lua' and lua_name == 'luajit'
+    lua_bin = 'luajit'
+  endif
+
+else
+  lua_dep = dependency(lua_name)
+endif
+
+lua_prog = find_program(lua_bin, required: false)
+if not lua_prog.found()
+  error('Failed to find lua binary, you can specify it manually with `-Dlua-bin=lua54`')
+endif
+
+# lua doesn't have an official pkg-config file so we guess off its version
+lua_version_split = lua_dep.version().split('.')
+lua_abi_version = '@0@.@1@'.format(lua_version_split[0], lua_version_split[1])
+
+# These are defined by the luajit.pc and some distros lua.pc
+lua_cpath = lua_dep.get_pkgconfig_variable('INSTALL_CMOD',
+  define_variable: ['prefix', get_option('prefix')],
+  default: join_paths(get_option('libdir'), 'lua', lua_abi_version),
+)
+lua_path = lua_dep.get_pkgconfig_variable('INSTALL_LMOD',
+  define_variable: ['prefix', get_option('prefix')],
+  default: join_paths(get_option('datadir'), 'lua', lua_abi_version)
+)
+
+gi_dep = dependency('gobject-introspection-1.0')
+gi_datadir = gi_dep.get_pkgconfig_variable('gidatadir')
+
+install_data('lgi.lua', install_dir: lua_path)
+subdir('lgi')
+if get_option('tests')
+  subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,9 @@
+option('lua-pc', type: 'string', value: 'auto',
+  description: 'pkg-config name of lua library to build against'
+)
+option('lua-bin', type: 'string', value: 'lua',
+  description: 'path to lua binary to test against'
+)
+option('tests', type: 'boolean', value: true,
+  description: 'build tests'
+)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,35 @@
+gnome = import('gnome')
+
+regress_sources = [
+  join_paths(gi_datadir, 'tests', 'regress.c'),
+  join_paths(gi_datadir, 'tests', 'regress.h'),
+]
+
+libregress = shared_library('regress',
+  sources: regress_sources,
+  c_args: '-w', # Not our warnings, ignore them
+  dependencies: [
+    dependency('gio-2.0'),
+    dependency('cairo-gobject'),
+  ]
+)
+
+regress_gir = gnome.generate_gir(libregress,
+  sources: regress_sources,
+  namespace: 'Regress',
+  nsversion: '1.0',
+  includes: ['Gio-2.0', 'cairo-1.0'],
+)
+
+dbus_run = find_program('dbus-run-session')
+test('regress', dbus_run,
+  # regress_gir being here is just a hack so it gets added as a dep
+  args: [lua_prog.path(), files('test.lua'), regress_gir],
+  env: [
+    'LD_LIBRARY_PATH=' + meson.current_build_dir(),
+    'GI_TYPELIB_PATH=' + meson.current_build_dir(),
+    # Build dir is added for generated version.lua
+    'LUA_PATH=@0@/?.lua;@1@/?.lua'.format(meson.source_root(), meson.build_root()),
+    'LUA_CPATH=@0@/?.so;@0@/?.dll'.format(meson.build_root())
+  ]
+)


### PR DESCRIPTION
This is very useful on Windows and it matches the rest of the stack such as `gobject-introspection` and `glib` which are moving to meson.