### PR TITLE
refsink cairo refcounted types

### DIFF
--- a/lgi/override/cairo.lua
+++ b/lgi/override/cairo.lua
@@ -660,11 +660,14 @@ for _, info in ipairs {
       local name = info[1]
       local obj = assert(cairo[name], name)
       obj._parent = info.parent
+      local cprefix = 'cairo_' .. (info.cprefix or core.uncamel(name) .. '_')
+      if not obj._parent then
+	 obj._refsink = cairo._module[cprefix .. 'reference']
+      end
       if info.methods then
 	 -- Go through description of the methods and create functions
 	 -- from them.
 	 obj._method = {}
-	 local cprefix = 'cairo_' .. (info.cprefix or core.uncamel(name) .. '_')
 	 local self_arg = { obj }
 	 for method_name, method_info in pairs(info.methods) do
 	    if cairo.version >= (method_info.since or 0) then

--- a/tests/cairo.lua
+++ b/tests/cairo.lua
@@ -447,3 +447,22 @@ function cairo.context_transform()
    compare(x, 10)
    compare(y, 20)
 end
+
+function cairo.pattern_reference()
+   local cairo = lgi.cairo
+
+   local img = cairo.ImageSurface(cairo.Format.RGB24, 42, 42)
+   local img2 = cairo.ImageSurface(cairo.Format.RGB24, 42, 42)
+   local cr = cairo.Context(img)
+   cr:set_source_surface(img2, 0, 0)
+
+   -- cairo_get_source() returns a pointer *without* acquiring a reference to it.
+   local source = cr.source
+
+   -- Let's make "cr" drop its reference to 'source'.
+   cr:set_source_rgb(0.2, 0.4, 0.6)
+
+   -- Now the reference count is zero and we would have a
+   -- use-after-free if custom refsink would not work correctly.
+   cr.source = source
+end


### PR DESCRIPTION
Some cairo types are reference-counted and provide their own custom
reference-counting. Hook up lgi's refsink mechanism to cairo's custom
reference functions, if the type has it.

https://github.com/pavouk/lgi/issues/210