### PR TITLE
tests/test.lua: Use os.exit() instead of return

### DIFF
--- a/tests/test.lua
+++ b/tests/test.lua
@@ -147,7 +147,7 @@ else
       local group, groupmask = mask:match('^(.-):(.+)$')
       if not group or not groups[group] then
 	 io.write(("No test group for mask `%s' found.\n"):format(mask))
-	 return 2
+	 os.exit(2)
       end
       groups[group]:run(groupmask)
       failed = failed or groups[group].results.failed > 0


### PR DESCRIPTION
Apparently, Lua ignores the return value of the main chunk. To make this
fail explicitly, this now calls io.exit() instead.

Note that this exposes a bug in the meson build, which now fails.

Signed-off-by: Uli Schlachter <psychon@znc.in>