### PR TITLE
meson: Run tests correctly

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('lgi', 'c',
   version: '0.9.2',
-  meson_version: '>= 0.44.0',
+  meson_version: '>= 0.46.0',
   default_options: [
     'warning_level=2',
     'buildtype=debugoptimized',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -23,8 +23,8 @@ regress_gir = gnome.generate_gir(libregress,
 
 dbus_run = find_program('dbus-run-session')
 test('regress', dbus_run,
-  # regress_gir being here is just a hack so it gets added as a dep
-  args: [lua_prog.path(), files('test.lua'), regress_gir],
+  args: [lua_prog.path(), files('test.lua')],
+  depends: regress_gir,
   env: [
     'LD_LIBRARY_PATH=' + meson.current_build_dir(),
     'GI_TYPELIB_PATH=' + meson.current_build_dir(),


### PR DESCRIPTION
There was a hack where some extra arguments are passed to the test
runner by meson. This hack was necessary so that some dependencies are
generated before the test itself was started. However, these arguments
were interpreted as a list of subtests to run and so no tests were
actually run.

Fix this by explicitly specifying these targets as dependencies. This is
possible in newer versions of meson, hence the required meson version
gets bumped.

Fixes: https://github.com/pavouk/lgi/issues/214
Signed-off-by: Uli Schlachter <psychon@znc.in>

CC @TingPing 