### PR TITLE
Fix bytestring handling with embedded null bytes

### DIFF
--- a/lgi/override/GLib-Variant.lua
+++ b/lgi/override/GLib-Variant.lua
@@ -122,7 +122,7 @@ function variant_new(format, pos, val)
    elseif t == 'a' then
       if format:sub(pos, pos) == 'y' then
 	 -- Bytestring is just simple Lua string.
-	 return Variant.new_bytestring(val), pos + 1
+	 return Variant.new_from_data(VariantType.BYTESTRING, val), pos + 1
       end
       local epos = read_format(format, pos)
       if not epos then return nil end
@@ -208,7 +208,7 @@ local function variant_get(v)
       end
       return array
    elseif Variant.is_of_type(v, VariantType.BYTESTRING) then
-      return tostring(Variant.get_bytestring(v))
+      return tostring(v.data)
    elseif Variant.is_of_type(v, VariantType.DICTIONARY) then
       -- Return proxy table which dynamically looks up items in the
       -- target variant.

--- a/tests/variant.lua
+++ b/tests/variant.lua
@@ -59,7 +59,7 @@ function variant.newv_basic()
    local vv = V.new('s', 'inner')
    v = V.new('v', vv)
    check(v.type == 'v' and v:get_variant() == vv)
-   v = V.new('ay', 'bytestring')
+   v = V.new('ay', 'bytestring\0')
    check(v.type == 'ay' and tostring(v:get_bytestring()) == 'bytestring')
 end
 
@@ -163,7 +163,10 @@ function variant.value_simple()
    check(V('g', '(ii)').value == '(ii)')
    v = V('i', 1)
    check(V('v', v).value == v)
-   check(V('ay', 'bytestring').value == 'bytestring')
+   local value = 'bytestring'
+   v = V('ay', value)
+   check(v:get_size() == #value)
+   check(v.value == value)
 end
 
 function variant.value_container()
@@ -261,4 +264,11 @@ if 42 == pairs(setmetatable({}, { __pairs = function() return 42 end })) then
         end
         check(seen == 2)
     end
+end
+
+function variant.bytestring_embedded_null()
+    local Variant = GLib.Variant
+    local value = '\0test\0'
+    local v = Variant('ay', value)
+    assert(v.value == value)
 end


### PR DESCRIPTION
This all started with me noticing that when transforming a bytestring to
Lua, the resulting string was truncated at the first null byte. I added
a new test variant.bytestring_embedded_null() (see diff) and started
trying to fix this test.

The fix is simple: Instead of using g_variant_get_bytestring() (which
only providers a pointer to the beginning of the data, but no length) to
transform the value to Lua, the code has to use the already existing
.data property. This code carefully gets the length of the bytestring
and creates a bytes object of appropriate length. Easy fix. This is
where the rabbit hole started.

The docs for g_variant_new_bytestring() say:

  The nul terminator character at the end of the string is stored in the
  array.

Thus, all existing code that creates a GVariant of type 'ay' from
strings actually include the terminating \0 byte. Since Lua strings have
explicit length, this behaviour is quite non-intuitive. To get a
GVariant bytestring without the terminating \0 byte, one possibility is
to use g_variant_new_from_data(). Thus, to fix some tests, this commit
changes the code to use that function for constructing GVariant objects
that really only contain what the given Lua string.

However, without a terminating \0 byte, g_variant_get_bytestring()
refuses to work and just returns a pointer to the empty string. This
broke the test variant.newv_basic(). To overcome that problem, the
GVariant used in the test was extended with a \0 byte.

The approach taken in this commit guarantees that converting from Lua
string -> GVariant bytestring -> Lua string produces the original Lua
string again. An alternative approach could be to just live with the
extra null byte that shows up. However, since that behaviour is quite
surprising, I went with the alternative approach instead: Getting rid of
this extra byte.

The approach I took however has a higher chance of causing breakage
elsewhere.

The original problem (.data truncating at the first embedded zero byte)
was first observed here (but the problem was not yet identified):
https://github.com/awesomeWM/awesome/pull/2722#issuecomment-475322079

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

@pavouk Could you take a look at this? This commit makes LGI slightly deviate from GLib's behaviour by not nul-terminating GVariant bytestrings. More details can be found in the commit message.