### PR TITLE
Fail gracefully on bad TreePath

### DIFF
--- a/lgi/override/Gtk.lua
+++ b/lgi/override/Gtk.lua
@@ -315,8 +315,11 @@ function Gtk.TreeModel:_element(model, key, origin)
    local natres = {tree_model_element(self, model, key, origin)}
    if #natres > 0 then return unpack(natres) end
    if model ~= nil and (type(key) == 'number' or type(key) == 'string') then
-      return model:get_iter(Gtk.TreePath.new_from_string(key)), '_iter'
-   end
+      local path = Gtk.TreePath.new_from_string(key)
+      if path then
+         return model:get_iter(path), '_iter'
+      end
+   end        
 end
 function Gtk.TreeModel:_access_iter(model, iter, ...)
    if select('#', ...) > 0 then

--- a/lgi/override/Gtk.lua
+++ b/lgi/override/Gtk.lua
@@ -319,7 +319,7 @@ function Gtk.TreeModel:_element(model, key, origin)
       if path then
          return model:get_iter(path), '_iter'
       end
-   end        
+   end
 end
 function Gtk.TreeModel:_access_iter(model, iter, ...)
    if select('#', ...) > 0 then

--- a/tests/gtk.lua
+++ b/tests/gtk.lua
@@ -398,5 +398,5 @@ end
 function gtk.treemodelsort_method()
    local Gtk = lgi.Gtk
    -- Shouldn't error when making TreePath, only print warning
-   local noop = lgi.Gtk.TreeModelSort().set_sort_func
+   local noop = Gtk.TreeModelSort().set_sort_func
 end

--- a/tests/gtk.lua
+++ b/tests/gtk.lua
@@ -394,3 +394,9 @@ function gtk.actiongroup_index()
    check(ag.action.a1 == a1)
    check(ag.action.a2 == a2)
 end
+
+function gtk.treemodelsort_method()
+   local Gtk = lgi.Gtk
+   -- Shouldn't error when making TreePath, only print warning
+   local noop = lgi.Gtk.TreeModelSort().set_sort_func
+end


### PR DESCRIPTION
Turned out that my #161 may lead to crashes under some conditions. This patch fixes that. For example, I got crash in `samples/gtk-demo/main.lua:102`.

Note: gtk warning still gets printed to console. I'm not really sure how much of a bug is this, but still better avoid crashing.