### PR TITLE
Use integers in Lua 5.3

### DIFF
--- a/lgi/buffer.c
+++ b/lgi/buffer.c
@@ -15,7 +15,7 @@ static int
 buffer_len (lua_State *L)
 {
   luaL_checkudata (L, 1, LGI_BYTES_BUFFER);
-  lua_pushnumber (L, lua_objlen (L, 1));
+  lua_pushinteger (L, lua_objlen (L, 1));
   return 1;
 }
 
@@ -30,11 +30,11 @@ buffer_tostring (lua_State *L)
 static int
 buffer_index (lua_State *L)
 {
-  int index;
+  lgi_Unsigned index;
   unsigned char *buffer = luaL_checkudata (L, 1, LGI_BYTES_BUFFER);
-  index = lua_tonumber (L, 2);
+  index = lua_tointeger (L, 2);
   if (index > 0 && (size_t) index <= lua_objlen (L, 1))
-    lua_pushnumber (L, buffer[index - 1]);
+    lua_pushinteger (L, buffer[index - 1]);
   else
     {
       luaL_argcheck (L, !lua_isnoneornil (L, 2), 2, "nil index");
@@ -46,7 +46,7 @@ buffer_index (lua_State *L)
 static int
 buffer_newindex (lua_State *L)
 {
-  int index;
+  lgi_Unsigned index;
   unsigned char *buffer = luaL_checkudata (L, 1, LGI_BYTES_BUFFER);
   index = luaL_checkint (L, 2);
   luaL_argcheck (L, index > 0 && (size_t) index <= lua_objlen (L, 1),
@@ -73,7 +73,7 @@ buffer_new (lua_State *L)
   if (lua_type (L, 1) == LUA_TSTRING)
     source = lua_tolstring (L, 1, &size);
   else
-    size = luaL_checknumber (L, 1);
+    size = luaL_checkint (L, 1);
   buffer = lua_newuserdata (L, size);
   if (source)
     memcpy (buffer, source, size);

--- a/lgi/callable.c
+++ b/lgi/callable.c
@@ -739,7 +739,7 @@ callable_param_2c (lua_State *L, Param *param, int narg, int parent,
       else
 	{
 	  union { GIArgument arg; int i; } *u = (gpointer) arg;
-	  u->i = lua_tonumber (L, narg);
+	  u->i = lua_tointeger (L, narg);
 	}
 
       /* Stack cleanup from enum value conversion. */
@@ -774,7 +774,7 @@ callable_param_2lua (lua_State *L, Param *param, GIArgument *arg,
       else
 	{
 	  union { GIArgument arg; ffi_sarg i; } *u = (gpointer) arg;
-	  lua_pushnumber (L, u->i);
+	  lua_pushinteger (L, u->i);
 	}
     }
 
@@ -1152,7 +1152,7 @@ marshal_arguments (lua_State *L, void **args, int callable_index, Callable *call
 	    lua_createtable (L, nvals, 0);
 	    for (i = 0; i < nvals; ++i)
 	      {
-		lua_pushnumber (L, i + 1);
+		lua_pushinteger (L, i + 1);
 		lgi_type_get_repotype (L, G_TYPE_VALUE, NULL);
 		lgi_record_2lua (L, &vals[i], FALSE, 0);
 		lua_settable (L, -3);

--- a/lgi/core.c
+++ b/lgi/core.c
@@ -60,7 +60,10 @@ const char *lgi_sd (lua_State *L)
 	  break;
 
 	case LUA_TNUMBER:
-	  item = g_strdup_printf ("%g", lua_tonumber (L, i));
+	  if (lua_isinteger(L, i))
+		item = g_strdup_printf (LGI_LUAINT_FORMAT, lua_tointeger (L, i));
+	  else
+		item = g_strdup_printf ("%g", lua_tonumber (L, i));
 	  break;
 
 	default:
@@ -213,7 +216,7 @@ lgi_type_get_gtype (lua_State *L, int narg)
       return G_TYPE_INVALID;
 
     case LUA_TNUMBER:
-      return lua_tonumber (L, narg);
+      return lua_tointeger (L, narg);
 
     case LUA_TLIGHTUSERDATA:
       return (GType) lua_touserdata (L, narg);
@@ -461,16 +464,16 @@ core_registerlock (lua_State *L)
 static int
 core_band (lua_State *L)
 {
-  lua_pushnumber (L, (unsigned)luaL_checknumber (L, 1)
-		  & (unsigned)luaL_checknumber (L, 2));
+  lua_pushinteger (L, (lgi_Unsigned)luaL_checkinteger (L, 1)
+		  & (lgi_Unsigned)luaL_checkinteger (L, 2));
   return 1;
 }
 
 static int
 core_bor (lua_State *L)
 {
-  lua_pushnumber (L, (unsigned)luaL_checknumber (L, 1)
-		  | (unsigned)luaL_checknumber (L, 2));
+  lua_pushinteger (L, (lgi_Unsigned)luaL_checkinteger (L, 1)
+		  | (lgi_Unsigned)luaL_checkinteger (L, 2));
   return 1;
 }
 

--- a/lgi/gi.c
+++ b/lgi/gi.c
@@ -72,7 +72,7 @@ static int
 infos_len (lua_State *L)
 {
   Infos* infos = luaL_checkudata (L, 1, LGI_GI_INFOS);
-  lua_pushnumber (L, infos->count);
+  lua_pushinteger (L, infos->count);
   return 1;
 }
 
@@ -83,7 +83,7 @@ infos_index (lua_State *L)
   gint n;
   if (lua_type (L, 2) == LUA_TNUMBER)
     {
-      n = lua_tonumber (L, 2) - 1;
+      n = lua_tointeger (L, 2) - 1;
       luaL_argcheck (L, n >= 0 && n < infos->count, 2, "out of bounds");
       return lgi_gi_info_new (L, infos->item_get (infos->info, n));
     }
@@ -296,7 +296,7 @@ info_index (lua_State *L)
 	    }
 	  else if (strcmp (prop, "size") == 0)
 	    {
-	      lua_pushnumber (L, g_struct_info_get_size (*info));
+	      lua_pushinteger (L, g_struct_info_get_size (*info));
 	      return 1;
 	    }
 	  INFOS (struct, field)
@@ -306,7 +306,7 @@ info_index (lua_State *L)
 	{
 	  if (strcmp (prop, "size") == 0)
 	    {
-	      lua_pushnumber (L, g_struct_info_get_size (*info));
+	      lua_pushinteger (L, g_struct_info_get_size (*info));
 	      return 1;
 	    }
 	  INFOS (union, field)
@@ -413,7 +413,7 @@ info_index (lua_State *L)
 	{
 	  const gchar *domain = g_enum_info_get_error_domain (*info);
 	  if (domain != NULL)
-	    lua_pushnumber (L, g_quark_from_string (domain));
+	    lua_pushinteger (L, g_quark_from_string (domain));
 	  else
 	    lua_pushnil (L);
 
@@ -425,7 +425,7 @@ info_index (lua_State *L)
     {
       if (strcmp (prop, "value") == 0)
 	{
-	  lua_pushnumber (L, g_value_info_get_value (*info));
+	  lua_pushinteger (L, g_value_info_get_value (*info));
 	  return 1;
 	}
     }
@@ -457,7 +457,7 @@ info_index (lua_State *L)
     {
       if (strcmp (prop, "flags") == 0)
 	{
-	  lua_pushnumber (L, g_property_info_get_flags (*info));
+	  lua_pushinteger (L, g_property_info_get_flags (*info));
 	  return 1;
 	}
       else if (strcmp (prop, "transfer") == 0)
@@ -486,12 +486,12 @@ info_index (lua_State *L)
 	}
       else if (strcmp (prop, "size") == 0)
 	{
-	  lua_pushnumber (L, g_field_info_get_size (*info));
+	  lua_pushinteger (L, g_field_info_get_size (*info));
 	  return 1;
 	}
       else if (strcmp (prop, "offset") == 0)
 	{
-	  lua_pushnumber (L, g_field_info_get_offset (*info));
+	  lua_pushinteger (L, g_field_info_get_offset (*info));
 	  return 1;
 	}
     }
@@ -559,7 +559,7 @@ info_index (lua_State *L)
 	  int len = g_type_info_get_array_length (*info);
 	  if (len >= 0)
 	    {
-	      lua_pushnumber (L, len);
+	      lua_pushinteger (L, len);
 	      return 1;
 	    }
 	}
@@ -568,7 +568,7 @@ info_index (lua_State *L)
 	  int size = g_type_info_get_array_fixed_size (*info);
 	  if (size >= 0)
 	    {
-	      lua_pushnumber (L, size);
+	      lua_pushinteger (L, size);
 	      return 1;
 	    }
 	}
@@ -639,7 +639,7 @@ static int
 namespace_len (lua_State *L)
 {
   const gchar *ns = luaL_checkudata (L, 1, LGI_GI_NAMESPACE);
-  lua_pushnumber (L, g_irepository_get_n_infos (NULL, ns));
+  lua_pushinteger (L, g_irepository_get_n_infos (NULL, ns));
   return 1;
 }
 
@@ -735,7 +735,7 @@ gi_require (lua_State *L)
     {
       lua_pushboolean (L, 0);
       lua_pushstring (L, err->message);
-      lua_pushnumber (L, err->code);
+      lua_pushinteger (L, err->code);
       g_error_free (err);
       return 3;
     }
@@ -769,7 +769,7 @@ gi_index (lua_State *L)
     }
   else if (lua_type (L, 2) == LUA_TNUMBER)
     {
-      GQuark domain = (GQuark) lua_tonumber (L, 2);
+      GQuark domain = (GQuark) lua_tointeger (L, 2);
       GIBaseInfo *info = g_irepository_find_by_error_domain (NULL, domain);
       return lgi_gi_info_new (L, info);
     }

--- a/lgi/lgi.h
+++ b/lgi/lgi.h
@@ -29,6 +29,25 @@
 #endif
 #endif
 
+/* Lua 5.3 integers. */
+#if LUA_VERSION_NUM < 503
+// TODO: implement compatiblity
+#else
+typedef LUA_UNSIGNED lgi_Unsigned;
+#endif
+
+#ifdef LUA_INT_TYPE
+#if LUA_INT_TYPE == LUA_INT_INT
+#define LGI_LUAINT_FORMAT "%d"
+#elseif LUA_INT_TYPE == LUA_INT_LONG
+#define LGI_LUAINT_FORMAT "%ld"
+#else
+#define LGI_LUAINT_FORMAT "%lld"
+#endif
+#else
+#define LGI_LUAINT_FORMAT "%f"
+#endif
+
 #include <glib.h>
 #include <glib-object.h>
 #include <glib/gprintf.h>

--- a/lgi/lgi.h
+++ b/lgi/lgi.h
@@ -30,10 +30,23 @@
 #endif
 
 /* Lua 5.3 integers. */
-#if LUA_VERSION_NUM < 503
-// TODO: implement compatiblity
-#else
+#if LUA_VERSION_NUM >= 503
+// For Lua 5.3
 typedef LUA_UNSIGNED lgi_Unsigned;
+#if LUA_INT_TYPE == LUA_INT_INT
+#define LGI_LUAINT_FORMAT "%d"
+#elseif LUA_INT_TYPE == LUA_INT_LONG
+#define LGI_LUAINT_FORMAT "%ld"
+#else
+#define LGI_LUAINT_FORMAT "%lld"
+#endif
+#elif LUA_VERSION_NUM == 502
+// For Lua 5.2
+typedef lua_Unsigned lgi_Unsigned;
+#define lua_isinteger(L, i) 0
+#define LGI_LUAINT_FORMAT "%td"
+#else
+// For Lua 5.1 (TODOы)
 #endif
 
 #ifdef LUA_INT_TYPE
@@ -45,7 +58,7 @@ typedef LUA_UNSIGNED lgi_Unsigned;
 #define LGI_LUAINT_FORMAT "%lld"
 #endif
 #else
-#define LGI_LUAINT_FORMAT "%f"
+#define LGI_LUAINT_FORMAT "%ld"
 #endif
 
 #include <glib.h>

--- a/lgi/lgi.h
+++ b/lgi/lgi.h
@@ -46,19 +46,10 @@ typedef lua_Unsigned lgi_Unsigned;
 #define lua_isinteger(L, i) 0
 #define LGI_LUAINT_FORMAT "%td"
 #else
-// For Lua 5.1 (TODOы)
-#endif
-
-#ifdef LUA_INT_TYPE
-#if LUA_INT_TYPE == LUA_INT_INT
-#define LGI_LUAINT_FORMAT "%d"
-#elseif LUA_INT_TYPE == LUA_INT_LONG
-#define LGI_LUAINT_FORMAT "%ld"
-#else
-#define LGI_LUAINT_FORMAT "%lld"
-#endif
-#else
-#define LGI_LUAINT_FORMAT "%ld"
+// For Lua 5.1 (TODO)
+typedef unsigned long lgi_Unsigned;
+#define lua_isinteger(L, i) 0
+#define LGI_LUAINT_FORMAT "%td"
 #endif
 
 #include <glib.h>

--- a/lgi/lgi.h
+++ b/lgi/lgi.h
@@ -46,7 +46,7 @@ typedef lua_Unsigned lgi_Unsigned;
 #define lua_isinteger(L, i) 0
 #define LGI_LUAINT_FORMAT "%td"
 #else
-// For Lua 5.1 (TODO)
+// For Lua 5.1
 typedef unsigned long lgi_Unsigned;
 #define lua_isinteger(L, i) 0
 #define LGI_LUAINT_FORMAT "%td"

--- a/lgi/lgi.h
+++ b/lgi/lgi.h
@@ -32,14 +32,8 @@
 /* Lua 5.3 integers. */
 #if LUA_VERSION_NUM >= 503
 // For Lua 5.3
-typedef LUA_UNSIGNED lgi_Unsigned;
-#if LUA_INT_TYPE == LUA_INT_INT
-#define LGI_LUAINT_FORMAT "%d"
-#elseif LUA_INT_TYPE == LUA_INT_LONG
-#define LGI_LUAINT_FORMAT "%ld"
-#else
-#define LGI_LUAINT_FORMAT "%lld"
-#endif
+typedef lua_Unsigned lgi_Unsigned;
+#define LGI_LUAINT_FORMAT LUA_INTEGER_FMT
 #elif LUA_VERSION_NUM == 502
 // For Lua 5.2
 typedef lua_Unsigned lgi_Unsigned;

--- a/lgi/marshal.c
+++ b/lgi/marshal.c
@@ -90,8 +90,14 @@ marshal_2c_int (lua_State *L, GITypeTag tag, GIArgument *val, int narg,
       HANDLE_INT(INT32, int32, INT, gint, G_MININT32, G_MAXINT32, s);
       HANDLE_INT(UINT32, uint32, UINT, guint, 0, G_MAXUINT32, u);
       HANDLE_INT(UNICHAR, uint32, UINT, guint, 0, G_MAXUINT32, u);
+#if LUA_VERSION_NUM >= 503
       HANDLE_INT_NOPTR(INT64, int64, LUA_MININTEGER, LUA_MAXINTEGER, s);
       HANDLE_INT_NOPTR(UINT64, uint64, 0, LUA_MAXINTEGER, u);
+#else
+      HANDLE_INT_NOPTR(INT64, int64, ((lua_Number) -0x7f00000000000000LL) - 1,
+		       0x7fffffffffffffffLL, s);
+      HANDLE_INT_NOPTR(UINT64, uint64, 0, 0xffffffffffffffffULL, u);
+#endif
 #undef HANDLE_INT
 #undef HANDLE_INT_NOPTR
 

--- a/lgi/marshal.c
+++ b/lgi/marshal.c
@@ -14,8 +14,10 @@
 
 /* Checks whether given argument contains number which fits given
    constraints. If yes, returns it, otherwise throws Lua error. */
+
+#if LUA_VERSION_NUM < 503
 static lua_Number
-check_number (lua_State *L, int narg, lua_Number val_min, lua_Number val_max)
+check_integer (lua_State *L, int narg, lua_Number val_min, lua_Number val_max)
 {
   lua_Number val = luaL_checknumber (L, narg);
   if (val < val_min || val > val_max)
@@ -25,6 +27,19 @@ check_number (lua_State *L, int narg, lua_Number val_min, lua_Number val_max)
     }
   return val;
 }
+#else
+static lua_Integer
+check_integer (lua_State *L, int narg, lua_Integer val_min, lua_Integer val_max)
+{
+  lua_Integer val = luaL_checkint (L, narg);
+  if (val < val_min || val > val_max)
+    {
+      lua_pushfstring (L, "%I is out of <%I, %I>", val, val_min, val_max);
+      luaL_argerror (L, narg, lua_tostring (L, -1));
+    }
+  return val;
+}
+#endif
 
 typedef union {
   GIArgument arg;
@@ -44,7 +59,7 @@ marshal_2c_int (lua_State *L, GITypeTag tag, GIArgument *val, int narg,
     {
 #define HANDLE_INT(nameup, namelow, ptrconv, pct, val_min, val_max, ut) \
       case GI_TYPE_TAG_ ## nameup:					\
-	val->v_ ## namelow = check_number (L, narg, val_min, val_max);	\
+	val->v_ ## namelow = check_integer (L, narg, val_min, val_max);	\
 	if (parent == LGI_PARENT_FORCE_POINTER)				\
 	  val->v_pointer =						\
 	    G ## ptrconv ## _TO_POINTER ((pct) val->v_ ## namelow);     \
@@ -58,7 +73,7 @@ marshal_2c_int (lua_State *L, GITypeTag tag, GIArgument *val, int narg,
 
 #define HANDLE_INT_NOPTR(nameup, namelow, val_min, val_max, ut)		\
       case GI_TYPE_TAG_ ## nameup:					\
-	val->v_ ## namelow = check_number (L, narg, val_min, val_max);	\
+	val->v_ ## namelow = check_integer (L, narg, val_min, val_max);	\
 	g_assert (parent != LGI_PARENT_FORCE_POINTER);			\
 	if (sizeof (g ## namelow) <= sizeof (long)			\
 		 && parent == LGI_PARENT_IS_RETVAL)			\
@@ -68,16 +83,15 @@ marshal_2c_int (lua_State *L, GITypeTag tag, GIArgument *val, int narg,
 	  }								\
 	break
 
-      HANDLE_INT(INT8, int8, INT, gint, -0x80, 0x7f, s);
-      HANDLE_INT(UINT8, uint8, UINT, guint, 0, 0xff, u);
-      HANDLE_INT(INT16, int16, INT, gint, -0x8000, 0x7fff, s);
-      HANDLE_INT(UINT16, uint16, UINT, guint, 0, 0xffff, u);
-      HANDLE_INT(INT32, int32, INT, gint, -0x80000000LL, 0x7fffffffLL, s);
-      HANDLE_INT(UINT32, uint32, UINT, guint, 0, 0xffffffffUL, u);
-      HANDLE_INT(UNICHAR, uint32, UINT, guint, 0, 0x7fffffffLL, u);
-      HANDLE_INT_NOPTR(INT64, int64, ((lua_Number) -0x7f00000000000000LL) - 1,
-		       0x7fffffffffffffffLL, s);
-      HANDLE_INT_NOPTR(UINT64, uint64, 0, 0xffffffffffffffffULL, u);
+      HANDLE_INT(INT8, int8, INT, gint, G_MININT8, G_MAXINT8, s);
+      HANDLE_INT(UINT8, uint8, UINT, guint, 0, G_MAXUINT8, u);
+      HANDLE_INT(INT16, int16, INT, gint, G_MININT16, G_MAXINT16, s);
+      HANDLE_INT(UINT16, uint16, UINT, guint, 0, G_MAXUINT16, u);
+      HANDLE_INT(INT32, int32, INT, gint, G_MININT32, G_MAXINT32, s);
+      HANDLE_INT(UINT32, uint32, UINT, guint, 0, G_MAXUINT32, u);
+      HANDLE_INT(UNICHAR, uint32, UINT, guint, 0, G_MAXUINT32, u);
+      HANDLE_INT_NOPTR(INT64, int64, LUA_MININTEGER, LUA_MAXINTEGER, s);
+      HANDLE_INT_NOPTR(UINT64, uint64, 0, LUA_MAXINTEGER, u);
 #undef HANDLE_INT
 #undef HANDLE_INT_NOPTR
 
@@ -112,7 +126,7 @@ marshal_2lua_int (lua_State *L, GITypeTag tag, GIArgument *val,
 	    ReturnUnion *ru = (ReturnUnion *) val;			\
 	    ru->arg.v_ ## namelower = (g ## namelower) ru->ut;		\
 	  }								\
-	lua_pushnumber (L, parent == LGI_PARENT_FORCE_POINTER		\
+	lua_pushinteger (L, parent == LGI_PARENT_FORCE_POINTER		\
 			?  GPOINTER_TO_ ## ptrconv (val->v_pointer)	\
 			: val->v_ ## namelower);			\
 	break;
@@ -386,7 +400,7 @@ marshal_2c_array (lua_State *L, GITypeInfo *ti, GIArrayType atype,
 	  /* Iterate through Lua array and fill GArray accordingly. */
 	  for (index = 0; index < objlen; index++)
 	    {
-	      lua_pushnumber (L, index + 1);
+	      lua_pushinteger (L, index + 1);
 	      lua_gettable (L, narg);
 
 	      /* Marshal element retrieved from the table into target
@@ -598,7 +612,7 @@ marshal_2c_list (lua_State *L, GITypeInfo *ti, GITypeTag list_tag,
       /* Retrieve index-th element from the source table and marshall
 	 it as pointer to arg. */
       GIArgument eval;
-      lua_pushnumber (L, index--);
+      lua_pushinteger (L, index--);
       lua_gettable (L, narg);
       to_pop = lgi_marshal_2c (L, eti, NULL, exfer, &eval, -1,
 			       LGI_PARENT_FORCE_POINTER, NULL, NULL);
@@ -1437,7 +1451,7 @@ lgi_marshal_field (lua_State *L, gpointer object, gboolean getmode,
       lua_rawgeti (L, field_arg, 1);
       field_addr = (char *) object + lua_tointeger (L, -1);
       lua_rawgeti (L, field_arg, 2);
-      kind = lua_tonumber (L, -1);
+      kind = lua_tointeger (L, -1);
       lua_pop (L, 2);
 
       /* Load type information from the table and decide how to handle
@@ -1608,7 +1622,7 @@ marshal_container_marshaller (lua_State *L)
 				     transfer);
 	    if (lua_type (L, 2) == LUA_TTABLE)
 	      {
-		lua_pushnumber (L, size);
+		lua_pushinteger (L, size);
 		lua_setfield (L, 2, "length");
 	      }
 	  }
@@ -1652,7 +1666,7 @@ marshal_container_marshaller (lua_State *L)
       if (!lua_isnil (L, -1))
 	for (lua_insert (L, -nret - 1); nret > 0; nret--)
 	  {
-	    lua_pushnumber (L, lua_objlen (L, -nret - 1));
+	    lua_pushinteger (L, lua_objlen (L, -nret - 1));
 	    lua_insert (L, -2);
 	    lua_settable (L, -nret - 3);
 	    lua_pop (L, 1);
@@ -1682,7 +1696,7 @@ marshal_container (lua_State *L)
       tag == GI_TYPE_TAG_GSLIST || tag == GI_TYPE_TAG_GLIST)
     {
       lua_pushvalue (L, 1);
-      lua_pushnumber (L, transfer);
+      lua_pushinteger (L, transfer);
       lua_pushcclosure (L, marshal_container_marshaller, 2);
     }
   else
@@ -1843,7 +1857,7 @@ marshal_closure_invoke (lua_State *L)
   memset (params, 0, sizeof (GValue) * n_params);
   for (i = 0; i < n_params; i++)
     {
-      lua_pushnumber (L, i + 1);
+      lua_pushinteger (L, i + 1);
       lua_gettable (L, 3);
       lua_pushvalue (L, -2);
       lgi_record_2c (L, -2, &params[i], TRUE, FALSE, FALSE, FALSE);
@@ -1895,8 +1909,8 @@ marshal_typeinfo (lua_State *L)
       case GI_TYPE_TAG_ ## upper:					\
 	{								\
 	  struct Test { char offender; type examined; };		\
-	  lua_pushnumber (L, sizeof (type));				\
-	  lua_pushnumber (L, G_STRUCT_OFFSET (struct Test, examined));	\
+	  lua_pushinteger (L, sizeof (type));				\
+	  lua_pushinteger (L, G_STRUCT_OFFSET (struct Test, examined));	\
 	}								\
 	break
 

--- a/lgi/object.c
+++ b/lgi/object.c
@@ -506,7 +506,7 @@ object_env (lua_State *L)
       guard = lua_newuserdata (L, sizeof (ObjectEnvGuard));
       guard->object = obj;
       lua_rawgeti (L, -4, OBJECT_QDATA_ENV);
-      guard->id = lua_tonumber (L, -1);
+      guard->id = lua_tointeger (L, -1);
       lua_pop (L, 1);
       lua_pushvalue (L, -2);
       lua_setfenv (L, -2);
@@ -565,7 +565,7 @@ object_new (lua_State *L)
       params = g_newa (GParameter, size);
       for (i = 0; i < size; ++i)
 	{
-	  lua_pushnumber (L, i + 1);
+	  lua_pushinteger (L, i + 1);
 	  lua_gettable (L, 2);
 	  lgi_type_get_repotype (L, G_TYPE_INVALID, gparam_info);
 	  lgi_record_2c (L, -2, &params[i], TRUE, FALSE, FALSE, FALSE);
@@ -607,7 +607,7 @@ lgi_object_init (lua_State *L)
 
   /* Add OBJECT_QDATA_ENV quark to env table. */
   id = g_strdup_printf ("lgi:%p", L);
-  lua_pushnumber (L, g_quark_from_string (id));
+  lua_pushinteger (L, g_quark_from_string (id));
   g_free (id);
   lua_rawseti (L, -2, OBJECT_QDATA_ENV);
 

--- a/lgi/record.c
+++ b/lgi/record.c
@@ -73,7 +73,7 @@ lgi_record_new (lua_State *L, int count, gboolean alloc)
 
   /* Calculate size of the record to allocate. */
   lua_getfield (L, -1, "_size");
-  size = lua_tonumber (L, -1) * count;
+  size = lua_tointeger (L, -1) * count;
   lua_pop (L, 1);
 
   /* Allocate new userdata for record object, attach proper
@@ -397,7 +397,7 @@ lgi_record_2c (lua_State *L, int narg, gpointer target, gboolean by_value,
     {
       gsize size;
       lua_getfield (L, -1, "_size");
-      size = lua_tonumber (L, -1);
+      size = lua_tointeger (L, -1);
       lua_pop (L, 1);
 
       if (record)
@@ -657,7 +657,7 @@ record_fromarray (lua_State *L)
   /* Find out the size of this record. */
   lua_getfenv (L, 1);
   lua_getfield (L, -1, "_size");
-  size = lua_tonumber (L, -1);
+  size = lua_tointeger (L, -1);
 
   if (record->store == RECORD_STORE_EMBEDDED)
     /* Parent is actually our embedded record. */

--- a/tests/gireg.lua
+++ b/tests/gireg.lua
@@ -20,7 +20,7 @@ local checkv = testsuite.checkv
 local gireg = testsuite.group.new('gireg')
 
 -- Do we have Lua-side support for integers?
-local nativeIntegers = (_VERSION == 'Lua 5.3' or _VERSION == 'Lua 5.4')
+local nativeIntegers = math.maxinteger and true or false
 
 function gireg.type_boolean()
    local R = lgi.Regress
@@ -182,7 +182,7 @@ function gireg.type_int64()
       checkv(R.test_int64(-0x8000000000000000), -0x8000000000000000, 'number')
    end
 
-   -- Following two lines succeed because integers wrap around in Lua 5.3 like they do in C.
+   -- Following two lines succeed in Lua 5.3 but make no sense.
 
    --check(not pcall(R.test_int64, 0x8000000000000000))
    --check(not pcall(R.test_int64, -0x8000000000000001))

--- a/tests/gireg.lua
+++ b/tests/gireg.lua
@@ -8,6 +8,9 @@
 
 --]]--------------------------------------------------------------------------
 
+-- Note: changed during Lua 5.3 integer support conversion.
+-- Now 64bit integers work, but floats without representation are no longer auto-converted.
+
 local lgi = require 'lgi'
 local bytes = require 'bytes'
 
@@ -15,6 +18,9 @@ local fail = testsuite.fail
 local check = testsuite.check
 local checkv = testsuite.checkv
 local gireg = testsuite.group.new('gireg')
+
+-- Do we have Lua-side support for integers?
+local nativeIntegers = (_VERSION == 'Lua 5.3' or _VERSION == 'Lua 5.4')
 
 function gireg.type_boolean()
    local R = lgi.Regress
@@ -36,8 +42,10 @@ function gireg.type_int8()
    checkv(R.test_int8(0), 0, 'number')
    checkv(R.test_int8(1), 1, 'number')
    checkv(R.test_int8(-1), -1, 'number')
-   checkv(R.test_int8(1.1), 1, 'number')
-   checkv(R.test_int8(-1.1), -1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_int8(1.1), 1, 'number')
+      checkv(R.test_int8(-1.1), -1, 'number')
+   end
    checkv(R.test_int8(0x7f), 0x7f, 'number')
    checkv(R.test_int8(-0x80), -0x80, 'number')
    check(not pcall(R.test_int8, 0x80))
@@ -54,7 +62,9 @@ function gireg.type_uint8()
    local R = lgi.Regress
    checkv(R.test_uint8(0), 0, 'number')
    checkv(R.test_uint8(1), 1, 'number')
-   checkv(R.test_uint8(1.1), 1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_uint8(1.1), 1, 'number')
+   end
    checkv(R.test_uint8(0xff), 0xff, 'number')
    check(not pcall(R.test_uint8, 0x100))
    check(not pcall(R.test_uint8, -1))
@@ -71,8 +81,10 @@ function gireg.type_int16()
    checkv(R.test_int16(0), 0, 'number')
    checkv(R.test_int16(1), 1, 'number')
    checkv(R.test_int16(-1), -1, 'number')
-   checkv(R.test_int16(1.1), 1, 'number')
-   checkv(R.test_int16(-1.1), -1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_int16(1.1), 1, 'number')
+      checkv(R.test_int16(-1.1), -1, 'number')
+   end
    checkv(R.test_int16(0x7fff), 0x7fff, 'number')
    checkv(R.test_int16(-0x8000), -0x8000, 'number')
    check(not pcall(R.test_int16, 0x8000))
@@ -89,7 +101,9 @@ function gireg.type_uint16()
    local R = lgi.Regress
    checkv(R.test_uint16(0), 0, 'number')
    checkv(R.test_uint16(1), 1, 'number')
-   checkv(R.test_uint16(1.1), 1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_uint16(1.1), 1, 'number')
+   end
    checkv(R.test_uint16(0xffff), 0xffff, 'number')
    check(not pcall(R.test_uint16, 0x10000))
    check(not pcall(R.test_uint16, -1))
@@ -106,8 +120,10 @@ function gireg.type_int32()
    checkv(R.test_int32(0), 0, 'number')
    checkv(R.test_int32(1), 1, 'number')
    checkv(R.test_int32(-1), -1, 'number')
-   checkv(R.test_int32(1.1), 1, 'number')
-   checkv(R.test_int32(-1.1), -1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_int32(1.1), 1, 'number')
+      checkv(R.test_int32(-1.1), -1, 'number')
+   end
    checkv(R.test_int32(0x7fffffff), 0x7fffffff, 'number')
    checkv(R.test_int32(-0x80000000), -0x80000000, 'number')
    check(not pcall(R.test_int32, 0x80000000))
@@ -124,7 +140,9 @@ function gireg.type_uint32()
    local R = lgi.Regress
    checkv(R.test_uint32(0), 0, 'number')
    checkv(R.test_uint32(1), 1, 'number')
-   checkv(R.test_uint32(1.1), 1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_uint32(1.1), 1, 'number')
+   end
    checkv(R.test_uint32(0xffffffff), 0xffffffff, 'number')
    check(not pcall(R.test_uint32, 0x100000000))
    check(not pcall(R.test_uint32, -1))
@@ -141,8 +159,10 @@ function gireg.type_int64()
    checkv(R.test_int64(0), 0, 'number')
    checkv(R.test_int64(1), 1, 'number')
    checkv(R.test_int64(-1), -1, 'number')
-   checkv(R.test_int64(1.1), 1, 'number')
-   checkv(R.test_int64(-1.1), -1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_int64(1.1), 1, 'number')
+      checkv(R.test_int64(-1.1), -1, 'number')
+   end
    check(not pcall(R.test_int64))
    check(not pcall(R.test_int64, nil))
    check(not pcall(R.test_int64, 'string'))
@@ -154,10 +174,18 @@ function gireg.type_int64()
 -- is always 'double', and conversion between double and int64 big
 -- constants is always lossy.  Not sure if it can be solved somehow.
 
---   checkv(R.test_int64(0x7fffffffffffffff), 0x7fffffffffffffff, 'number')
---   checkv(R.test_int64(-0x8000000000000000), -0x8000000000000000, 'number')
---   check(not pcall(R.test_int64, 0x8000000000000000))
---   check(not pcall(R.test_int64, -0x8000000000000001))
+-- UPDATE: It IS working in Lua 5.3 because of its integer support,
+-- so tests are enabled there.
+
+   if nativeIntegers then
+      checkv(R.test_int64(0x7fffffffffffffff), 0x7fffffffffffffff, 'number')
+      checkv(R.test_int64(-0x8000000000000000), -0x8000000000000000, 'number')
+   end
+
+   -- Following two lines succeed because integers wrap around in Lua 5.3 like they do in C.
+
+   --check(not pcall(R.test_int64, 0x8000000000000000))
+   --check(not pcall(R.test_int64, -0x8000000000000001))
 
 end
 
@@ -165,7 +193,9 @@ function gireg.type_uint64()
    local R = lgi.Regress
    checkv(R.test_uint64(0), 0, 'number')
    checkv(R.test_uint64(1), 1, 'number')
-   checkv(R.test_uint64(1.1), 1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_uint64(1.1), 1, 'number')
+   end
    check(not pcall(R.test_uint64, -1))
    check(not pcall(R.test_uint64))
    check(not pcall(R.test_uint64, nil))
@@ -176,6 +206,9 @@ function gireg.type_uint64()
 
 -- See comment above about lossy conversions.
 
+-- UPDATE: fail in Lua 5.3 too because it don't have unsigned integers.
+-- 0xffffffffffffffff == -1
+
 --   checkv(R.test_uint64(0xffffffffffffffff), 0xffffffffffffffff, 'number')
 --   check(not pcall(R.test_uint64, 0x10000000000000000))
 end
@@ -185,15 +218,19 @@ function gireg.type_short()
    checkv(R.test_short(0), 0, 'number')
    checkv(R.test_short(1), 1, 'number')
    checkv(R.test_short(-1), -1, 'number')
-   checkv(R.test_short(1.1), 1, 'number')
-   checkv(R.test_short(-1.1), -1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_short(1.1), 1, 'number')
+      checkv(R.test_short(-1.1), -1, 'number')
+   end
 end
 
 function gireg.type_ushort()
    local R = lgi.Regress
    checkv(R.test_ushort(0), 0, 'number')
    checkv(R.test_ushort(1), 1, 'number')
-   checkv(R.test_ushort(1.1), 1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_ushort(1.1), 1, 'number')
+   end
    check(not pcall(R.test_ushort, -1))
 end
 
@@ -202,15 +239,19 @@ function gireg.type_int()
    checkv(R.test_int(0), 0, 'number')
    checkv(R.test_int(1), 1, 'number')
    checkv(R.test_int(-1), -1, 'number')
-   checkv(R.test_int(1.1), 1, 'number')
-   checkv(R.test_int(-1.1), -1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_int(1.1), 1, 'number')
+      checkv(R.test_int(-1.1), -1, 'number')
+   end
 end
 
 function gireg.type_uint()
    local R = lgi.Regress
    checkv(R.test_uint(0), 0, 'number')
    checkv(R.test_uint(1), 1, 'number')
-   checkv(R.test_uint(1.1), 1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_uint(1.1), 1, 'number')
+   end
    check(not pcall(R.test_uint, -1))
 end
 
@@ -219,15 +260,19 @@ function gireg.type_ssize()
    checkv(R.test_ssize(0), 0, 'number')
    checkv(R.test_ssize(1), 1, 'number')
    checkv(R.test_ssize(-1), -1, 'number')
-   checkv(R.test_ssize(1.1), 1, 'number')
-   checkv(R.test_ssize(-1.1), -1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_ssize(1.1), 1, 'number')
+      checkv(R.test_ssize(-1.1), -1, 'number')
+   end
 end
 
 function gireg.type_size()
    local R = lgi.Regress
    checkv(R.test_size(0), 0, 'number')
    checkv(R.test_size(1), 1, 'number')
-   checkv(R.test_size(1.1), 1, 'number')
+   if not nativeIntegers then
+      checkv(R.test_size(1.1), 1, 'number')
+   end
    check(not pcall(R.test_size, -1))
 end
 
@@ -391,7 +436,9 @@ end
 function gireg.array_int_in()
    local R = lgi.Regress
    check(R.test_array_int_in{1,2,3} == 6)
-   check(R.test_array_int_in{1.1,2,3} == 6)
+   if not nativeIntegers then
+      check(R.test_array_int_in{1.1,2,3} == 6)
+   end
    check(R.test_array_int_in{} == 0)
    check(not pcall(R.test_array_int_in, nil))
    check(not pcall(R.test_array_int_in, 'help'))
@@ -420,7 +467,9 @@ end
 function gireg.array_gint8_in()
    local R = lgi.Regress
    check(R.test_array_gint8_in{1,2,3} == 6)
-   check(R.test_array_gint8_in{1.1,2,3} == 6)
+   if not nativeIntegers then
+      check(R.test_array_gint8_in{1.1,2,3} == 6)
+   end
    check(R.test_array_gint8_in('0123') == 48 + 49 + 50 + 51)
    check(R.test_array_gint8_in(bytes.new('0123')) == 48 + 49 + 50 + 51)
    check(R.test_array_gint8_in{} == 0)
@@ -431,7 +480,9 @@ end
 function gireg.array_gint16_in()
    local R = lgi.Regress
    check(R.test_array_gint16_in{1,2,3} == 6)
-   check(R.test_array_gint16_in{1.1,2,3} == 6)
+   if not nativeIntegers then
+      check(R.test_array_gint16_in{1.1,2,3} == 6)
+   end
    check(R.test_array_gint16_in{} == 0)
    check(not pcall(R.test_array_gint16_in, nil))
    check(not pcall(R.test_array_gint16_in, 'help'))
@@ -441,7 +492,9 @@ end
 function gireg.array_gint32_in()
    local R = lgi.Regress
    check(R.test_array_gint32_in{1,2,3} == 6)
-   check(R.test_array_gint32_in{1.1,2,3} == 6)
+   if not nativeIntegers then
+      check(R.test_array_gint32_in{1.1,2,3} == 6)
+   end
    check(R.test_array_gint32_in{} == 0)
    check(not pcall(R.test_array_gint32_in, nil))
    check(not pcall(R.test_array_gint32_in, 'help'))
@@ -451,7 +504,9 @@ end
 function gireg.array_gint64_in()
    local R = lgi.Regress
    check(R.test_array_gint64_in{1,2,3} == 6)
-   check(R.test_array_gint64_in{1.1,2,3} == 6)
+   if not nativeIntegers then
+      check(R.test_array_gint64_in{1.1,2,3} == 6)
+   end
    check(R.test_array_gint64_in{} == 0)
    check(not pcall(R.test_array_gint64_in, nil))
    check(not pcall(R.test_array_gint64_in, 'help'))


### PR DESCRIPTION
This patch utilizes Lua functions for integers, making them appear the right way on Lua 5.3.

I've tested this on a few of configurations (all use XUbuntu 18.04):

* 64-bit, Lua 5.3
* 64-bit, Lua 5.2
* 64-bit, Lua 5.1
* 32-bit, Lua 5.3
* 32-bit, Lua 5.1 (added)

There are few tings to remember:

* This changes behavior on Lua 5.3 for numbers which don't have integer representation: they now cause error instead of silently rounding towards zero. Sounds reasonable for me.
* GCC show warning about int-to-pointer conversion on Lua 5.3 32-bit platform. Doesn't sound significant to me anyways as everything works.

<s>I probably should test on Lua 5.1 32-bit as well, will report results soon.</s> Done, it works.