### PR TITLE
Honour CPPFLAGS during build

### DIFF
--- a/lgi/Makefile
+++ b/lgi/Makefile
@@ -62,7 +62,7 @@ clean :
 	rm -f $(CORE) $(OBJS)
 
 %.o : %.c
-	$(CC) $(ALL_CFLAGS) -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(ALL_CFLAGS) -c -o $@ $<
 
 $(CORE) : $(OBJS)
 	$(CC) $(ALL_LDFLAGS) -o $@ $(OBJS) $(LIBS)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -70,10 +70,10 @@ $(REGRESS) : regress.o
 GIDATADIR = $(shell $(PKG_CONFIG) --variable=gidatadir gobject-introspection-1.0)/tests
 
 regress.o : $(GIDATADIR)/regress.c $(GIDATADIR)/regress.h $(DEPCHECK)
-	$(CC) $(ALL_CFLAGS) -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(ALL_CFLAGS) -c -o $@ $<
 
 test_c.o : test_c.c $(DEPCHECK)
-	$(CC) $(ALL_CFLAGS) -c -o $@ $<
+	$(CC) $(CPPFLAGS) $(ALL_CFLAGS) -c -o $@ $<
 
 test_c : test_c.o
 	$(CC) $(LDFLAGS) -o $@ $< $(LIBS)


### PR DESCRIPTION
With this change, CPPFLAGS set by the build system are honoured.