### PR TITLE
Add experimental support for Lua 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ LGI is tested and compatible with standard Lua 5.1, Lua 5.2, Lua 5.3 and
 LuaJIT2.  Compatibility with other Lua implementations is not tested
 yet.
 
+Lua 5.4 is only supported experimentally. It builds, but does not pass the
+test suite. See [#247](https://github.com/pavouk/lgi/issues/247) for details.
+
 If you need to support pre-gobject-introspection GTK (ancient GTK+ 2.x
 releases), use [Lua-Gnome](http://sourceforge.net/projects/lua-gnome/).
 

--- a/lgi/callable.c
+++ b/lgi/callable.c
@@ -1355,7 +1355,10 @@ closure_callback (ffi_cif *cif, void *ret, void **args, void *closure_arg)
     }
   else
     {
-#if LUA_VERSION_NUM >= 502
+#if LUA_VERSION_NUM >= 504
+      int nresults;
+      res = lua_resume (L, NULL, npos, &nresults);
+#elif LUA_VERSION_NUM >= 502
       res = lua_resume (L, NULL, npos);
 #else
       res = lua_resume (L, npos);


### PR DESCRIPTION
This is the part of #199 that makes the build against Lua 5.4 pass. However, Lua 5.4 is not added to Travis since it does not pass the test suite. Thus, this is only experimental support.

Let's hope that someone magically shows up and figures out what the problem is...