### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 sudo: required
 dist: trusty
 language: c
+arch:
+ - amd64
+ - ppc64le
+
 env:
   matrix:
     - LUA=5.1 LUANAME=luajit-2.0 LUA_LIB=-lluajit-5.1
     - LUA=5.1 LUANAME=lua5.1
     - LUA=5.2 LUANAME=lua5.2
     - LUA=5.3 LUANAME=lua5.3 LUA_LIB=-llua
+jobs:
+  exclude:
+    - arch: ppc64le
+      env: LUA=5.1 LUANAME=luajit-2.0 LUA_LIB=-lluajit-5.1
 
 before_install:
   - if [ -z $LUAINCLUDE ]; then LUAINCLUDE=/usr/include/${LUANAME}; fi


### PR DESCRIPTION
Hi,
I had added ppc64le support on Travis-ci and Its been success added and build. Kindly review and merge same.

Changes done are added ppc64le arch and exclude LUANAME=luajit-2.0  since its not supporting ppc64le Arch.

The Travis ci build logs can be verified from the link below.
https://travis-ci.com/github/zazzel/lgi/builds/206977452
Please have a look.

Thank you