### PR TITLE
[DRAFT] Port to girepository-2.0

### DIFF
--- a/lgi/gi.c
+++ b/lgi/gi.c
@@ -13,6 +13,21 @@
 
 typedef GIBaseInfo *(* InfosItemGet)(GIBaseInfo* info, gint item);
 
+GIRepository *
+lgi_gi_get_repository (void)
+{
+  static GIRepository *repository;
+
+  if (repository == NULL)
+#if GLIB_CHECK_VERSION(2, 85, 0)
+    repository = gi_repository_dup_default ();
+#else
+    repository = gi_repository_new ();
+#endif
+
+  return repository;
+}
+
 /* Creates new instance of info from given GIBaseInfo pointer. */
 int
 lgi_gi_info_new (lua_State *L, GIBaseInfo *info)
@@ -21,18 +36,12 @@ lgi_gi_info_new (lua_State *L, GIBaseInfo *info)
     {
       GIBaseInfo **ud_info;
 
-      if (g_base_info_get_type (info) == GI_INFO_TYPE_INVALID)
-	{
-	  g_base_info_unref (info);
-	  lua_pushnil (L);
-	}
-      else
-	{
-	  ud_info = lua_newuserdata (L, sizeof (info));
-	  *ud_info = info;
-	  luaL_getmetatable (L, LGI_GI_INFO);
-	  lua_setmetatable (L, -2);
-	}
+      g_assert (GI_IS_BASE_INFO (info));
+
+      ud_info = lua_newuserdata (L, sizeof (info));
+      *ud_info = info;
+      luaL_getmetatable (L, LGI_GI_INFO);
+      lua_setmetatable (L, -2);
     }
   else
     lua_pushnil (L);
@@ -50,8 +59,9 @@ lgi_gi_load_function (lua_State *L, int typetable, const char *name)
   lua_getfield (L, typetable, name);
   info = lgi_udata_test (L, -1, LGI_GI_INFO);
   if (info && GI_IS_FUNCTION_INFO (*info))
-      g_typelib_symbol (g_base_info_get_typelib (*info),
-                        g_function_info_get_symbol (*info), &symbol);
+      gi_typelib_symbol (gi_base_info_get_typelib (*info),
+                         gi_function_info_get_symbol (GI_FUNCTION_INFO (*info)),
+                         &symbol);
   else if (lua_islightuserdata (L, -1))
     symbol = lua_touserdata (L, -1);
   lua_pop (L, 1);
@@ -93,10 +103,10 @@ infos_index (lua_State *L)
       for (n = 0; n < infos->count; n++)
 	{
 	  GIBaseInfo *info = infos->item_get (infos->info, n);
-	  if (strcmp (g_base_info_get_name (info), name) == 0)
+	  if (strcmp (gi_base_info_get_name (info), name) == 0)
 	    return lgi_gi_info_new (L, info);
 
-	  g_base_info_unref (info);
+	  gi_base_info_unref (info);
 	}
 
       lua_pushnil (L);
@@ -108,7 +118,7 @@ static int
 infos_gc (lua_State *L)
 {
   Infos *infos = luaL_checkudata (L, 1, LGI_GI_INFOS);
-  g_base_info_unref (infos->info);
+  gi_base_info_unref (infos->info);
 
   /* Unset the metatable / make the infos unusable */
   lua_pushnil (L);
@@ -123,7 +133,7 @@ infos_new (lua_State *L, GIBaseInfo *info, gint count, InfosItemGet item_get)
   Infos *infos = lua_newuserdata (L, sizeof (Infos));
   luaL_getmetatable (L, LGI_GI_INFOS);
   lua_setmetatable (L, -2);
-  infos->info = g_base_info_ref (info);
+  infos->info = gi_base_info_ref (info);
   infos->count = count;
   infos->item_get = item_get;
   return 1;
@@ -159,49 +169,47 @@ info_index (lua_State *L)
   GIBaseInfo **info = luaL_checkudata (L, 1, LGI_GI_INFO);
   const gchar *prop = luaL_checkstring (L, 2);
 
-#define INFOS(n1, n2)							\
-  else if (strcmp (prop, #n2 "s") == 0)					\
-    return infos_new (L, *info,						\
-		      g_ ## n1 ## _info_get_n_ ## n2 ## s (*info),	\
-		      g_ ## n1 ## _info_get_ ## n2);
+#define INFOS(n1, n2)								\
+  else if (strcmp (prop, #n2 "s") == 0)						\
+    return infos_new (L, GI_BASE_INFO (*info),					\
+		      gi_ ## n1 ## _info_get_n_ ## n2 ## s ((gpointer)*info),	\
+		      (InfosItemGet) gi_ ## n1 ## _info_get_ ## n2);
 
-#define INFOS2(n1, n2, n3)					\
-  else if (strcmp (prop, #n3) == 0)				\
-    return infos_new (L, *info,					\
-		      g_ ## n1 ## _info_get_n_ ## n3 (*info),	\
-		      g_ ## n1 ## _info_get_ ## n2);
+#define INFOS2(n1, n2, n3)							\
+  else if (strcmp (prop, #n3) == 0)						\
+    return infos_new (L, GI_BASE_INFO (*info),					\
+		      gi_ ## n1 ## _info_get_n_ ## n3 ((gpointer)*info),	\
+		      (InfosItemGet) gi_ ## n1 ## _info_get_ ## n2);
 
   if (strcmp (prop, "type") == 0)
     {
-      switch (g_base_info_get_type (*info))
-	{
 #define H(n1, n2)				\
-	  case GI_INFO_TYPE_ ## n1:		\
-	    lua_pushstring (L, #n2);		\
-	    return 1;
+      else if (GI_IS_ ## n1 ## _INFO (*info))   \
+        {                                       \
+          lua_pushstring (L, #n2);              \
+          return 1;                             \
+        }
 
-	  H(FUNCTION, function)
-	    H(CALLBACK, callback)
-	    H(STRUCT, struct)
-	    H(BOXED, boxed)
-	    H(ENUM, enum)
-	    H(FLAGS, flags)
-	    H(OBJECT, object)
-	    H(INTERFACE, interface)
-	    H(CONSTANT, constant)
-	    H(UNION, union)
-	    H(VALUE, value)
-	    H(SIGNAL, signal)
-	    H(VFUNC, vfunc)
-	    H(PROPERTY, property)
-	    H(FIELD, field)
-	    H(ARG, arg)
-	    H(TYPE, type)
-	    H(UNRESOLVED, unresolved)
+      if (0) {}
+      H(FUNCTION, function)
+      H(CALLBACK, callback)
+      H(STRUCT, struct)
+      H(ENUM, enum)
+      H(FLAGS, flags)
+      H(OBJECT, object)
+      H(INTERFACE, interface)
+      H(CONSTANT, constant)
+      H(UNION, union)
+      H(VALUE, value)
+      H(SIGNAL, signal)
+      H(VFUNC, vfunc)
+      H(PROPERTY, property)
+      H(FIELD, field)
+      H(ARG, arg)
+      H(TYPE, type)
+      H(UNRESOLVED, unresolved)
+      else g_assert_not_reached ();
 #undef H
-	default:
-	  g_assert_not_reached ();
-	}
     }
 
 #define H(n1, n2)						\
@@ -232,12 +240,12 @@ info_index (lua_State *L)
     {
       if (strcmp (prop, "name") == 0)
 	{
-	  lua_pushstring (L, g_base_info_get_name (*info));
+	  lua_pushstring (L, gi_base_info_get_name (*info));
 	  return 1;
 	}
       else if (strcmp (prop, "namespace") == 0)
 	{
-	  lua_pushstring (L, g_base_info_get_namespace (*info));
+	  lua_pushstring (L, gi_base_info_get_namespace (*info));
 	  return 1;
 	}
     }
@@ -250,37 +258,37 @@ info_index (lua_State *L)
 
   if (strcmp (prop, "deprecated") == 0)
     {
-      lua_pushboolean (L, g_base_info_is_deprecated (*info));
+      lua_pushboolean (L, gi_base_info_is_deprecated (*info));
       return 1;
     }
   else if (strcmp (prop, "container") == 0)
     {
-      GIBaseInfo *container = g_base_info_get_container (*info);
+      GIBaseInfo *container = gi_base_info_get_container (*info);
       if (container)
-	g_base_info_ref (container);
+	gi_base_info_ref (container);
       return lgi_gi_info_new (L, container);
     }
   else if (strcmp (prop, "typeinfo") == 0)
     {
       GITypeInfo *ti = NULL;
       if (GI_IS_ARG_INFO (*info))
-	ti = g_arg_info_get_type (*info);
+	ti = gi_arg_info_get_type_info (GI_ARG_INFO (*info));
       else if (GI_IS_CONSTANT_INFO (*info))
-	ti = g_constant_info_get_type (*info);
+	ti = gi_constant_info_get_type_info (GI_CONSTANT_INFO (*info));
       else if (GI_IS_PROPERTY_INFO (*info))
-	ti = g_property_info_get_type (*info);
+	ti = gi_property_info_get_type_info (GI_PROPERTY_INFO (*info));
       else if (GI_IS_FIELD_INFO (*info))
-	ti = g_field_info_get_type (*info);
+	ti = gi_field_info_get_type_info (GI_FIELD_INFO (*info));
 
       if (ti)
-	return lgi_gi_info_new (L, ti);
+	return lgi_gi_info_new (L, GI_BASE_INFO (ti));
     }
 
   if (GI_IS_REGISTERED_TYPE_INFO (*info))
     {
       if (strcmp (prop, "gtype") == 0)
 	{
-	  GType gtype = g_registered_type_info_get_g_type (*info);
+	  GType gtype = gi_registered_type_info_get_g_type (GI_REGISTERED_TYPE_INFO (*info));
 	  if (gtype != G_TYPE_NONE)
 	    lua_pushlightuserdata (L, (void *) gtype);
 	  else
@@ -291,12 +299,12 @@ info_index (lua_State *L)
 	{
 	  if (strcmp (prop, "is_gtype_struct") == 0)
 	    {
-	      lua_pushboolean (L, g_struct_info_is_gtype_struct (*info));
+	      lua_pushboolean (L, gi_struct_info_is_gtype_struct (GI_STRUCT_INFO (*info)));
 	      return 1;
 	    }
 	  else if (strcmp (prop, "size") == 0)
 	    {
-	      lua_pushinteger (L, g_struct_info_get_size (*info));
+	      lua_pushinteger (L, gi_struct_info_get_size (GI_STRUCT_INFO (*info)));
 	      return 1;
 	    }
 	  INFOS (struct, field)
@@ -306,7 +314,7 @@ info_index (lua_State *L)
 	{
 	  if (strcmp (prop, "size") == 0)
 	    {
-	      lua_pushinteger (L, g_struct_info_get_size (*info));
+	      lua_pushinteger (L, gi_struct_info_get_size (GI_STRUCT_INFO (*info)));
 	      return 1;
 	    }
 	  INFOS (union, field)
@@ -316,7 +324,7 @@ info_index (lua_State *L)
 	{
 	  if (strcmp (prop, "type_struct") == 0)
 	    return
-	      lgi_gi_info_new (L, g_interface_info_get_iface_struct (*info));
+	      lgi_gi_info_new (L, GI_BASE_INFO (gi_interface_info_get_iface_struct (GI_INTERFACE_INFO (*info))));
 	  INFOS (interface, prerequisite)
 	    INFOS (interface, vfunc)
 	    INFOS (interface, method)
@@ -327,9 +335,9 @@ info_index (lua_State *L)
       else if (GI_IS_OBJECT_INFO (*info))
 	{
 	  if (strcmp (prop, "parent") == 0)
-	    return lgi_gi_info_new (L, g_object_info_get_parent (*info));
+	    return lgi_gi_info_new (L, GI_BASE_INFO (gi_object_info_get_parent (GI_OBJECT_INFO (*info))));
 	  else if (strcmp (prop, "type_struct") == 0)
-	    return lgi_gi_info_new (L, g_object_info_get_class_struct (*info));
+	    return lgi_gi_info_new (L, GI_BASE_INFO (gi_object_info_get_class_struct (GI_OBJECT_INFO (*info))));
 	  INFOS (object, interface)
 	    INFOS (object, field)
 	    INFOS (object, vfunc)
@@ -343,16 +351,16 @@ info_index (lua_State *L)
   if (GI_IS_CALLABLE_INFO (*info))
     {
       if (strcmp (prop, "return_type") == 0)
-	return lgi_gi_info_new (L, g_callable_info_get_return_type (*info));
+	return lgi_gi_info_new (L, GI_BASE_INFO (gi_callable_info_get_return_type (GI_CALLABLE_INFO (*info))));
       else if (strcmp (prop, "return_transfer") == 0)
-	return info_push_transfer (L, g_callable_info_get_caller_owns (*info));
+	return info_push_transfer (L, gi_callable_info_get_caller_owns (GI_CALLABLE_INFO (*info)));
       INFOS (callable, arg);
 
       if (GI_IS_SIGNAL_INFO (*info))
 	{
 	  if (strcmp (prop, "flags") == 0)
 	    {
-	      GSignalFlags flags = g_signal_info_get_flags (*info);
+	      GSignalFlags flags = gi_signal_info_get_flags (GI_SIGNAL_INFO (*info));
 	      lua_newtable (L);
 #define H(n1, n2)					\
 	      if ((flags & G_SIGNAL_ ## n1) != 0)	\
@@ -376,7 +384,7 @@ info_index (lua_State *L)
 	{
 	  if (strcmp (prop, "flags") == 0)
 	    {
-	      GIFunctionInfoFlags flags = g_function_info_get_flags (*info);
+	      GIFunctionInfoFlags flags = gi_function_info_get_flags (GI_FUNCTION_INFO (*info));
 	      lua_newtable (L);
 	      if (0);
 #define H(n1, n2)					\
@@ -386,23 +394,22 @@ info_index (lua_State *L)
 		  lua_setfield (L, -2, #n2);		\
 		}
 	      H(IS_METHOD, is_method)
-		H(IS_CONSTRUCTOR, is_constructor)
-		H(IS_GETTER, is_getter)
-		H(IS_SETTER, is_setter)
-		H(WRAPS_VFUNC, wraps_vfunc)
-		H(THROWS, throws);
+              H(IS_CONSTRUCTOR, is_constructor)
+              H(IS_GETTER, is_getter)
+              H(IS_SETTER, is_setter)
+              H(WRAPS_VFUNC, wraps_vfunc)
 #undef H
 	      return 1;
 	    }
 	}
     }
 
-  if (GI_IS_ENUM_INFO (*info))
+  if (GI_IS_ENUM_INFO (*info) || GI_IS_FLAGS_INFO (*info))
     {
       if (strcmp (prop, "storage") == 0)
 	{
-	  GITypeTag tag = g_enum_info_get_storage_type (*info);
-	  lua_pushstring (L, g_type_tag_to_string (tag));
+	  GITypeTag tag = gi_enum_info_get_storage_type (GI_ENUM_INFO (*info));
+	  lua_pushstring (L, gi_type_tag_to_string (tag));
 	  return 1;
 	}
 #if GLIB_CHECK_VERSION (2, 30, 0)
@@ -411,7 +418,7 @@ info_index (lua_State *L)
 	INFOS (enum, value)
       else if (strcmp (prop, "error_domain") == 0)
 	{
-	  const gchar *domain = g_enum_info_get_error_domain (*info);
+	  const gchar *domain = gi_enum_info_get_error_domain (GI_ENUM_INFO (*info));
 	  if (domain != NULL)
 	    lua_pushinteger (L, g_quark_from_string (domain));
 	  else
@@ -425,7 +432,7 @@ info_index (lua_State *L)
     {
       if (strcmp (prop, "value") == 0)
 	{
-	  lua_pushinteger (L, g_value_info_get_value (*info));
+	  lua_pushinteger (L, gi_value_info_get_value (GI_VALUE_INFO (*info)));
 	  return 1;
 	}
     }
@@ -434,9 +441,9 @@ info_index (lua_State *L)
     {
       if (strcmp (prop, "direction") == 0)
 	{
-	  GIDirection dir = g_arg_info_get_direction (*info);
+	  GIDirection dir = gi_arg_info_get_direction (GI_ARG_INFO (*info));
 	  if (dir == GI_DIRECTION_OUT)
-	    lua_pushstring (L, g_arg_info_is_caller_allocates (*info)
+	    lua_pushstring (L, gi_arg_info_is_caller_allocates (GI_ARG_INFO (*info))
 			    ? "out-caller-alloc" : "out");
 	  else
 	    lua_pushstring (L, dir == GI_DIRECTION_IN ? "in" : "inout");
@@ -444,11 +451,11 @@ info_index (lua_State *L)
 	}
       if (strcmp (prop, "transfer") == 0)
 	return info_push_transfer (L,
-				   g_arg_info_get_ownership_transfer (*info));
+				   gi_arg_info_get_ownership_transfer (GI_ARG_INFO (*info)));
       if (strcmp (prop, "optional") == 0)
 	{
-	  lua_pushboolean (L, g_arg_info_is_optional (*info)
-			   || g_arg_info_may_be_null (*info));
+	  lua_pushboolean (L, gi_arg_info_is_optional (GI_ARG_INFO (*info))
+			   || gi_arg_info_may_be_null (GI_ARG_INFO (*info)));
 	  return 1;
 	}
     }
@@ -457,20 +464,20 @@ info_index (lua_State *L)
     {
       if (strcmp (prop, "flags") == 0)
 	{
-	  lua_pushinteger (L, g_property_info_get_flags (*info));
+	  lua_pushinteger (L, gi_property_info_get_flags (GI_PROPERTY_INFO (*info)));
 	  return 1;
 	}
       else if (strcmp (prop, "transfer") == 0)
 	return
 	  info_push_transfer (L,
-			      g_property_info_get_ownership_transfer (*info));
+			      gi_property_info_get_ownership_transfer (GI_PROPERTY_INFO (*info)));
     }
 
   if (GI_IS_FIELD_INFO (*info))
     {
       if (strcmp (prop, "flags") == 0)
 	{
-	  GIFieldInfoFlags flags = g_field_info_get_flags (*info);
+	  GIFieldInfoFlags flags = gi_field_info_get_flags (GI_FIELD_INFO (*info));
 	  lua_newtable (L);
 	  if (0);
 #define H(n1, n2)					\
@@ -486,27 +493,27 @@ info_index (lua_State *L)
 	}
       else if (strcmp (prop, "size") == 0)
 	{
-	  lua_pushinteger (L, g_field_info_get_size (*info));
+	  lua_pushinteger (L, gi_field_info_get_size (GI_FIELD_INFO (*info)));
 	  return 1;
 	}
       else if (strcmp (prop, "offset") == 0)
 	{
-	  lua_pushinteger (L, g_field_info_get_offset (*info));
+	  lua_pushinteger (L, gi_field_info_get_offset (GI_FIELD_INFO (*info)));
 	  return 1;
 	}
     }
 
   if (GI_IS_TYPE_INFO (*info))
     {
-      GITypeTag tag = g_type_info_get_tag (*info);
+      GITypeTag tag = gi_type_info_get_tag (GI_TYPE_INFO (*info));
       if (strcmp (prop, "tag") == 0)
 	{
-	  lua_pushstring (L, g_type_tag_to_string (tag));
+	  lua_pushstring (L, gi_type_tag_to_string (tag));
 	  return 1;
 	}
       else if (strcmp (prop, "is_basic") == 0)
 	{
-	  lua_pushboolean (L, G_TYPE_TAG_IS_BASIC (tag));
+	  lua_pushboolean (L, GI_TYPE_TAG_IS_BASIC (tag));
 	  return 1;
 	}
       else if (strcmp (prop, "params") == 0)
@@ -515,11 +522,11 @@ info_index (lua_State *L)
 	      tag == GI_TYPE_TAG_GSLIST || tag == GI_TYPE_TAG_GHASH)
 	    {
 	      lua_newtable (L);
-	      lgi_gi_info_new (L, g_type_info_get_param_type (*info, 0));
+	      lgi_gi_info_new (L, GI_BASE_INFO (gi_type_info_get_param_type (GI_TYPE_INFO (*info), 0)));
 	      lua_rawseti (L, -2, 1);
 	      if (tag == GI_TYPE_TAG_GHASH)
 		{
-		  lgi_gi_info_new (L, g_type_info_get_param_type (*info, 1));
+		  lgi_gi_info_new (L, GI_BASE_INFO (gi_type_info_get_param_type (GI_TYPE_INFO (*info), 1)));
 		  lua_rawseti (L, -2, 2);
 		}
 	      return 1;
@@ -527,12 +534,12 @@ info_index (lua_State *L)
 	}
       else if (strcmp (prop, "interface") == 0 && tag == GI_TYPE_TAG_INTERFACE)
 	{
-	  lgi_gi_info_new (L, g_type_info_get_interface (*info));
+	  lgi_gi_info_new (L, gi_type_info_get_interface (GI_TYPE_INFO (*info)));
 	  return 1;
 	}
       else if (strcmp (prop, "array_type") == 0 && tag == GI_TYPE_TAG_ARRAY)
 	{
-	  switch (g_type_info_get_array_type (*info))
+	  switch (gi_type_info_get_array_type (GI_TYPE_INFO (*info)))
 	    {
 #define H(n1, n2)				\
 	      case GI_ARRAY_TYPE_ ## n1:	\
@@ -551,13 +558,13 @@ info_index (lua_State *L)
       else if (strcmp (prop, "is_zero_terminated") == 0
 	       && tag == GI_TYPE_TAG_ARRAY)
 	{
-	  lua_pushboolean (L, g_type_info_is_zero_terminated (*info));
+	  lua_pushboolean (L, gi_type_info_is_zero_terminated (GI_TYPE_INFO (*info)));
 	  return 1;
 	}
       else if (strcmp (prop, "array_length") == 0)
 	{
-	  int len = g_type_info_get_array_length (*info);
-	  if (len >= 0)
+          guint len;
+          if (gi_type_info_get_array_length_index (GI_TYPE_INFO (*info), &len))
 	    {
 	      lua_pushinteger (L, len);
 	      return 1;
@@ -565,8 +572,8 @@ info_index (lua_State *L)
 	}
       else if (strcmp (prop, "fixed_size") == 0)
 	{
-	  int size = g_type_info_get_array_fixed_size (*info);
-	  if (size >= 0)
+          gsize size;
+          if (gi_type_info_get_array_fixed_size (GI_TYPE_INFO (*info), &size))
 	    {
 	      lua_pushinteger (L, size);
 	      return 1;
@@ -574,7 +581,7 @@ info_index (lua_State *L)
 	}
       else if (strcmp (prop, "is_pointer") == 0)
 	{
-	  lua_pushboolean (L, g_type_info_is_pointer (*info));
+	  lua_pushboolean (L, gi_type_info_is_pointer (GI_TYPE_INFO (*info)));
 	  return 1;
 	}
     }
@@ -591,7 +598,7 @@ info_eq (lua_State *L)
 {
   GIBaseInfo **i1 = luaL_checkudata (L, 1, LGI_GI_INFO);
   GIBaseInfo **i2 = luaL_checkudata (L, 2, LGI_GI_INFO);
-  lua_pushboolean (L, g_base_info_equal (*i1, *i2));
+  lua_pushboolean (L, gi_base_info_equal (*i1, *i2));
   return 1;
 }
 
@@ -599,7 +606,7 @@ static int
 info_gc (lua_State *L)
 {
   GIBaseInfo **info = luaL_checkudata (L, 1, LGI_GI_INFO);
-  g_base_info_unref (*info);
+  gi_base_info_unref (*info);
   return 0;
 }
 
@@ -618,7 +625,7 @@ resolver_index (lua_State *L)
 {
   gpointer address;
   GITypelib **typelib = luaL_checkudata (L, 1, LGI_GI_RESOLVER);
-  if (g_typelib_symbol (*typelib, luaL_checkstring (L, 2), &address))
+  if (gi_typelib_symbol (*typelib, luaL_checkstring (L, 2), &address))
     {
       lua_pushlightuserdata (L, address);
       return 1;
@@ -639,7 +646,7 @@ static int
 namespace_len (lua_State *L)
 {
   const gchar *ns = luaL_checkudata (L, 1, LGI_GI_NAMESPACE);
-  lua_pushinteger (L, g_irepository_get_n_infos (NULL, ns));
+  lua_pushinteger (L, gi_repository_get_n_infos (lgi_gi_get_repository (), ns));
   return 1;
 }
 
@@ -650,14 +657,14 @@ namespace_index (lua_State *L)
   const gchar *prop;
   if (lua_type (L, 2) == LUA_TNUMBER)
     {
-      GIBaseInfo *info = g_irepository_get_info (NULL, ns,
+      GIBaseInfo *info = gi_repository_get_info (lgi_gi_get_repository (), ns,
 						 lua_tointeger (L, 2) - 1);
       return lgi_gi_info_new (L, info);
     }
   prop = luaL_checkstring (L, 2);
   if (strcmp (prop, "dependencies") == 0)
     {
-      gchar **deps = g_irepository_get_dependencies (NULL, ns);
+      gchar **deps = gi_repository_get_dependencies (lgi_gi_get_repository (), ns, NULL);
       if (deps == NULL)
 	lua_pushnil (L);
       else
@@ -679,7 +686,7 @@ namespace_index (lua_State *L)
     }
   else if (strcmp (prop, "version") == 0)
     {
-      lua_pushstring (L, g_irepository_get_version (NULL, ns));
+      lua_pushstring (L, gi_repository_get_version (lgi_gi_get_repository (), ns));
       return 1;
     }
   else if (strcmp (prop, "name") == 0)
@@ -692,12 +699,12 @@ namespace_index (lua_State *L)
       GITypelib **udata = lua_newuserdata (L, sizeof (GITypelib *));
       luaL_getmetatable (L, LGI_GI_RESOLVER);
       lua_setmetatable (L, -2);
-      *udata = g_irepository_require (NULL, ns, NULL, 0, NULL);
+      *udata = gi_repository_require (lgi_gi_get_repository (), ns, NULL, 0, NULL);
       return 1;
     }
   else
     /* Try to lookup the symbol. */
-    return lgi_gi_info_new (L, g_irepository_find_by_name (NULL, ns, prop));
+    return lgi_gi_info_new (L, gi_repository_find_by_name (lgi_gi_get_repository (), ns, prop));
 }
 
 static int
@@ -727,9 +734,9 @@ gi_require (lua_State *L)
   GITypelib *typelib;
 
   if (typelib_dir == NULL)
-    typelib = g_irepository_require (NULL, namespace, version, 0, &err);
+    typelib = gi_repository_require (lgi_gi_get_repository (), namespace, version, 0, &err);
   else
-    typelib = g_irepository_require_private (NULL, typelib_dir, namespace,
+    typelib = gi_repository_require_private (lgi_gi_get_repository (), typelib_dir, namespace,
 					     version, 0, &err);
   if (!typelib)
     {
@@ -764,19 +771,19 @@ gi_index (lua_State *L)
     {
       GType gtype = (GType) lua_touserdata (L, 2);
       GIBaseInfo *info = (gtype != G_TYPE_INVALID)
-	? g_irepository_find_by_gtype (NULL, gtype) : NULL;
+	? gi_repository_find_by_gtype (lgi_gi_get_repository (), gtype) : NULL;
       return lgi_gi_info_new (L, info);
     }
   else if (lua_type (L, 2) == LUA_TNUMBER)
     {
       GQuark domain = (GQuark) lua_tointeger (L, 2);
-      GIBaseInfo *info = g_irepository_find_by_error_domain (NULL, domain);
+      GIBaseInfo *info = GI_BASE_INFO (gi_repository_find_by_error_domain (lgi_gi_get_repository (), domain));
       return lgi_gi_info_new (L, info);
     }
   else
     {
       const gchar *ns = luaL_checkstring (L, 2);
-      if (g_irepository_is_registered (NULL, ns, NULL))
+      if (gi_repository_is_registered (lgi_gi_get_repository (), ns, NULL))
 	return namespace_new (L, ns);
     }
 
@@ -827,37 +834,37 @@ lgi_gi_init (lua_State *L)
 }
 
 #if !GLIB_CHECK_VERSION(2, 30, 0)
-/* Workaround for broken g_struct_info_get_size() for GValue, see
+/* Workaround for broken gi_struct_info_get_size() for GValue, see
    https://bugzilla.gnome.org/show_bug.cgi?id=657040 */
 static GIStructInfo *parameter_info = NULL;
 static GIFieldInfo *parameter_value_info = NULL;
 
-#undef g_struct_info_get_size
+#undef gi_struct_info_get_size
 gsize
 lgi_struct_info_get_size (GIStructInfo *info)
 {
   if (parameter_info == NULL)
-    parameter_info = g_irepository_find_by_name (NULL, "GObject", "Parameter");
+    parameter_info = gi_repository_find_by_name (lgi_gi_get_repository (), "GObject", "Parameter");
   if (g_registered_type_info_get_g_type (info) == G_TYPE_VALUE)
     return sizeof (GValue);
-  else if (parameter_info && g_base_info_equal (info, parameter_info))
+  else if (parameter_info && gi_base_info_equal (info, parameter_info))
     return sizeof (GParameter);
-  return g_struct_info_get_size (info);
+  return gi_struct_info_get_size (info);
 }
 
-#undef g_field_info_get_offset
+#undef gi_field_info_get_offset
 gint
 lgi_field_info_get_offset (GIFieldInfo *info)
 {
   if (parameter_value_info == NULL)
     {
       if (parameter_info == NULL)
-	parameter_info = g_irepository_find_by_name (NULL,
+	parameter_info = gi_repository_find_by_name (lgi_gi_get_repository (),
 						     "GObject", "Parameter");
-      parameter_value_info = g_struct_info_get_field (parameter_info, 1);
+      parameter_value_info = gi_struct_info_get_field (parameter_info, 1);
     }
-  if (parameter_value_info && g_base_info_equal (info, parameter_value_info))
+  if (parameter_value_info && gi_base_info_equal (info, parameter_value_info))
     return G_STRUCT_OFFSET (GParameter, value);
-  return g_field_info_get_offset (info);
+  return gi_field_info_get_offset (info);
 }
 #endif

--- a/lgi/lgi.h
+++ b/lgi/lgi.h
@@ -49,7 +49,7 @@ typedef unsigned long lgi_Unsigned;
 #include <glib.h>
 #include <glib-object.h>
 #include <glib/gprintf.h>
-#include <girepository.h>
+#include <girepository/girepository.h>
 #include <gmodule.h>
 
 /* Makes sure that Lua stack offset is absolute one, not relative. */
@@ -221,3 +221,5 @@ int lgi_field_info_get_offset (GIFieldInfo *info);
    in GI 1.32.0. (see https://bugzilla.gnome.org/show_bug.cgi?id=673282) */
 gpointer lgi_object_get_function_ptr (GIObjectInfo *info,
 				      const gchar *(*getter)(GIObjectInfo *));
+
+GIRepository *lgi_gi_get_repository (void);

--- a/lgi/marshal.c
+++ b/lgi/marshal.c
@@ -366,7 +366,7 @@ marshal_2c_array (lua_State *L, GITypeInfo *ti, GIArrayType atype,
 	  /* Find out how long array should we allocate. */
 	  zero_terminated = gi_type_info_is_zero_terminated (ti);
 	  objlen = lua_objlen (L, narg);
-          if (atype != GI_ARRAY_TYPE_C || !gi_type_info_get_array_fixed_size (ti, (gsize *)&out_size))
+          if (atype != GI_ARRAY_TYPE_C || !gi_type_info_get_array_fixed_size (ti, (gsize *)out_size))
 	    *out_size = objlen;
 	  else if (*out_size < objlen)
 	    objlen = *out_size;

--- a/meson.build
+++ b/meson.build
@@ -74,7 +74,7 @@ else
   lua_path = join_paths(get_option('datadir'), 'lua', lua_abi_version)
 endif
 
-gi_dep = dependency('gobject-introspection-1.0')
+gi_dep = dependency('girepository-2.0', version: '>= 2.80')
 gi_datadir = gi_dep.get_pkgconfig_variable('gidatadir')
 
 install_data('lgi.lua', install_dir: lua_path)


### PR DESCRIPTION
This is an initial port of lgi to use girepository-2.0 introduced in the GLib 2.80 release.

If using 2.85, it will use the new gi_repository_dup_default() function to ensure the repository is using the same repository as applications and libraries such as libpeas.

There is still some work to be done, as libpeas tests do not yet pass using this version of lgi. But I wanted to get some feedback on things and some extra eyes.

In particular, I'm seeing this when running the libpeas unit tests.

```
** (/home/christian/Projects/libpeas/build/tests/libpeas/extension-lua:331247): WARNING **: 13:35:52.864: Error loading plugin 'extension-lua51':
/home/christian/.jhbuild/share/lua/5.1/lgi/class.lua:354: bad argument #8 to 'register_static' (number expected, got table)
stack traceback:
	[C]: in function 'register_static'
	/home/christian/.jhbuild/share/lua/5.1/lgi/class.lua:354: in function 'derive'
	.../tests/libpeas/plugins/extension-lua/extension-lua51.lua:26: in main chunk
	[C]: at 0xfffef9ea86e0
	[C]: in function 'xpcall'
```

Which has code like:

```
-- Register new type with GType system.
local gtype = register_static(self._gtype, g_typename, type_info, {})
```

and presumably the failure is converting the `{}` to the flags.

Anyway, still trying to dig that out.