### PR TITLE
docs(guide.md): remove binary buffers

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -85,7 +85,6 @@ mapping between GLib types and Lua types is established.
   direction, following values are accepted for `gpointer` type:
     - Lua `string` instances
     - Instances of lgi classes, structs or unions
-    - Binary buffers (see below)
 
 ### 2.1. Calling functions and methods
 


### PR DESCRIPTION
The binary buffer mentioned here was removed in commit 9240e4e.
which is why the reference to “see below” here leads nowhere.