### PR TITLE
ffi: Adapt load_enum to glib 2.87 changes

### DIFF
--- a/lgi/ffi.lua
+++ b/lgi/ffi.lua
@@ -75,16 +75,22 @@ end
 
 -- Creates new enum/flags table with all values from specified gtype.
 function ffi.load_enum(gtype, name)
-   local GObject = core.repo.GObject
+   local GLib, GObject = core.repo.GLib, core.repo.GObject
    local is_flags = GObject.Type.is_a(gtype, GObject.Type.FLAGS)
    local enum_component = component.create(
       gtype, is_flags and enum.bitflags_mt or enum.enum_mt, name)
    local type_class = GObject.TypeClass.ref(gtype)
    local enum_class = core.record.cast(
       type_class, is_flags and GObject.FlagsClass or GObject.EnumClass)
-   for i = 0, enum_class.n_values - 1 do
-      local val = core.record.fromarray(enum_class.values, i)
-      enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+   if GLib.check_version(2, 87, 0) then
+      for i = 0, enum_class.n_values - 1 do
+         local val = core.record.fromarray(enum_class.values, i)
+         enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+      end
+   else
+      for _, val in ipairs(enum_class.values) do
+         enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+      end
    end
    type_class:unref()
    return enum_component


### PR DESCRIPTION
After glib change https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4803,
the `values` field is bound as an array with type `table` rather than `record`.
We can iterate over the array with ipairs().
