### PR TITLE
chore: remove unused callable_cache

### DIFF
--- a/lgi/callable.c
+++ b/lgi/callable.c
@@ -177,9 +177,6 @@ struct _FfiClosureBlock
   FfiClosure *ffi_closures[1];
 };
 
-/* lightuserdata key to callable cache table. */
-static int callable_cache;
-
 /* Gets ffi_type for given tag, returns NULL if it cannot be handled. */
 static ffi_type *
 get_simple_ffi_type (GITypeTag tag)
@@ -1580,9 +1577,6 @@ lgi_callable_init (lua_State *L)
   lua_newtable (L);
   luaL_register (L, NULL, callable_reg);
   lua_rawset (L, LUA_REGISTRYINDEX);
-
-  /* Create cache for callables. */
-  lgi_cache_create (L, &callable_cache, NULL);
 
   /* Create public api for callable module. */
   lua_newtable (L);


### PR DESCRIPTION
The callable_cache was created but never used.
I'm not sure where it should be used either.
Once I figure it out, we'll add it back in. 