### PR TITLE
chore: clear warning

### DIFF
--- a/lgi/core.c
+++ b/lgi/core.c
@@ -576,7 +576,7 @@ core_module (lua_State *L)
     }
 
   /* Embed the module in the userdata for the module. */
-  *(GModule **) lua_newuserdata (L, sizeof (module)) = module;
+  *(GModule **) lua_newuserdata (L, sizeof (GModule *)) = module;
   luaL_getmetatable (L, UD_MODULE);
   lua_setmetatable (L, -2);
 

--- a/lgi/gi.c
+++ b/lgi/gi.c
@@ -28,7 +28,7 @@ lgi_gi_info_new (lua_State *L, GIBaseInfo *info)
 	}
       else
 	{
-	  ud_info = lua_newuserdata (L, sizeof (info));
+	  ud_info = lua_newuserdata (L, sizeof (GIBaseInfo *));
 	  *ud_info = info;
 	  luaL_getmetatable (L, LGI_GI_INFO);
 	  lua_setmetatable (L, -2);


### PR DESCRIPTION
clear warning
`warning| Suspicious usage of 'sizeof()' on an expression of pointer type`