### PR TITLE
update(meson): improve support for Lua 5.4 and 5.5

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,9 +18,11 @@ add_project_arguments(cc.get_supported_arguments(test_c_args), language: 'c')
 
 lua_possible_names = [
   'lua',
-  'lua5.3', 'lua53',
-  'lua5.2', 'lua52',
-  'lua5.1', 'lua51',
+  'lua5.5', 'lua-5.5', 'lua55', 'lua-55',
+  'lua5.4', 'lua-5.4', 'lua54', 'lua-54',
+  'lua5.3', 'lua-5.3', 'lua53', 'lua-53',
+  'lua5.2', 'lua-5.2', 'lua52', 'lua-52',
+  'lua5.1', 'lua-5.1', 'lua51', 'lua-51',
   'luajit'
 ]
 


### PR DESCRIPTION
## Description

On Unix distros, there is no consensus about the pkg-config name for a versioned Lua release. So, I added more patterns to detect different Lua releases (including the recent Lua 5.5) using pkg-config, mostly in the direction of Debian testing: [https://packages.debian.org/forky/amd64/liblua5.5-dev/filelist](https://packages.debian.org/forky/amd64/liblua5.5-dev/filelist).

I was recommended to open this PR at [https://github.com/lgi-devs/lgi/pull/359#issuecomment-4187790985](https://github.com/lgi-devs/lgi/pull/359#issuecomment-4187790985).