### PR TITLE
fix: bring the test suite back to the pass state on newer GLib

### DIFF
--- a/lgi/ffi.lua
+++ b/lgi/ffi.lua
@@ -74,19 +74,39 @@ function ffi.load_gtype(resolver, get_type_name)
 end
 
 -- Creates new enum/flags table with all values from specified gtype.
+--
+-- Fixes https://github.com/lgi-devs/lgi/issues/358
+--
+-- Implementation for the fix was mirrored from the LGI fork:
+--   https://github.com/vtrlx/LuaGObject/blob/0.10.5/LuaGObject/ffi.lua#L74-L104
 function ffi.load_enum(gtype, name)
-   local GObject = core.repo.GObject
+   local GLib, GObject = core.repo.GLib, core.repo.GObject
    local is_flags = GObject.Type.is_a(gtype, GObject.Type.FLAGS)
    local enum_component = component.create(
       gtype, is_flags and enum.bitflags_mt or enum.enum_mt, name)
-   local type_class = GObject.TypeClass.ref(gtype)
+   local type_class
+   -- GLib >= 2.86 deprecates GObject.TypeClass.ref() in favour of .get()
+   if GLib.check_version(2, 86, 0) then
+      type_class = GObject.TypeClass.ref(gtype)
+   else
+      type_class = GObject.TypeClass.get(gtype)
+   end
    local enum_class = core.record.cast(
       type_class, is_flags and GObject.FlagsClass or GObject.EnumClass)
-   for i = 0, enum_class.n_values - 1 do
-      local val = core.record.fromarray(enum_class.values, i)
-      enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+   if GLib.check_version(2, 87, 0) then
+      for i = 0, enum_class.n_values - 1 do
+         local val = core.record.fromarray(enum_class.values, i)
+         enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+      end
+   else
+      for _, val in ipairs(enum_class.values) do
+         enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
+      end
    end
-   type_class:unref()
+   -- For GLib versions below 2.86, type_class was ref'd and needs to be unref'd
+   if GLib.check_version(2, 86, 0) then
+      type_class:unref()
+   end
    return enum_component
 end
 

--- a/lgi/ffi.lua
+++ b/lgi/ffi.lua
@@ -80,6 +80,7 @@ function ffi.load_enum(gtype, name)
    local enum_component = component.create(
       gtype, is_flags and enum.bitflags_mt or enum.enum_mt, name)
    local type_class
+   -- GLib >= 2.86 deprecates GObject.TypeClass.ref() in favour of .get()
    if GLib.check_version(2, 86, 0) then
       type_class = GObject.TypeClass.ref(gtype)
    else
@@ -97,6 +98,7 @@ function ffi.load_enum(gtype, name)
          enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
       end
    end
+   -- For GLib versions below 2.86, type_class was ref'd and needs to be unref'd
    if GLib.check_version(2, 86, 0) then
       type_class:unref()
    end

--- a/lgi/ffi.lua
+++ b/lgi/ffi.lua
@@ -74,18 +74,12 @@ function ffi.load_gtype(resolver, get_type_name)
 end
 
 -- Creates new enum/flags table with all values from specified gtype.
---
--- Fixes https://github.com/lgi-devs/lgi/issues/358
---
--- Implementation for the fix was mirrored from the LGI fork:
---   https://github.com/vtrlx/LuaGObject/blob/0.10.5/LuaGObject/ffi.lua#L74-L104
 function ffi.load_enum(gtype, name)
    local GLib, GObject = core.repo.GLib, core.repo.GObject
    local is_flags = GObject.Type.is_a(gtype, GObject.Type.FLAGS)
    local enum_component = component.create(
       gtype, is_flags and enum.bitflags_mt or enum.enum_mt, name)
    local type_class
-   -- GLib >= 2.86 deprecates GObject.TypeClass.ref() in favour of .get()
    if GLib.check_version(2, 86, 0) then
       type_class = GObject.TypeClass.ref(gtype)
    else
@@ -103,7 +97,6 @@ function ffi.load_enum(gtype, name)
          enum_component[core.upcase(val.value_nick):gsub('%-', '_')] = val.value
       end
    end
-   -- For GLib versions below 2.86, type_class was ref'd and needs to be unref'd
    if GLib.check_version(2, 86, 0) then
       type_class:unref()
    end

--- a/tests/pango.lua
+++ b/tests/pango.lua
@@ -35,8 +35,24 @@ function pango.glyphstring()
       local offset = items[i].offset
       local length = items[i].length
       local analysis = items[i].analysis
-      local pgs = Pango.GlyphString()
-      Pango.shape(string.sub(s,1+offset), length, analysis, pgs)
+      --
+      -- Fixes https://github.com/lgi-devs/lgi/issues/336
+      --
+      -- Implementation for the fix was a combination
+      -- of ideas from:
+      --
+      -- 1) my own investigation plus trial-error
+      -- 2) the comment: https://github.com/lgi-devs/lgi/issues/336#issuecomment-2888361271
+      -- 3) the LGI fork: https://github.com/vtrlx/LuaGObject/blob/0.10.5/tests/pango.lua#L38-L39
+      --
+      local pgs
+      if Pango.version_check(1, 56, 2) then
+         pgs = Pango.GlyphString()
+         Pango.shape(string.sub(s,1+offset), length, analysis, pgs)
+      else
+         pgs = Pango.shape(string.sub(s,1+offset), length, analysis)
+      end
+
       -- Pull out individual glyphs with pgs.glyphs
       local glyphs = pgs.glyphs
       check(type(glyphs) == 'table')

--- a/tests/pango.lua
+++ b/tests/pango.lua
@@ -35,16 +35,6 @@ function pango.glyphstring()
       local offset = items[i].offset
       local length = items[i].length
       local analysis = items[i].analysis
-      --
-      -- Fixes https://github.com/lgi-devs/lgi/issues/336
-      --
-      -- Implementation for the fix was a combination
-      -- of ideas from:
-      --
-      -- 1) my own investigation plus trial-error
-      -- 2) the comment: https://github.com/lgi-devs/lgi/issues/336#issuecomment-2888361271
-      -- 3) the LGI fork: https://github.com/vtrlx/LuaGObject/blob/0.10.5/tests/pango.lua#L38-L39
-      --
       local pgs
       if Pango.version_check(1, 56, 2) then
          pgs = Pango.GlyphString()

--- a/tests/progress.lua
+++ b/tests/progress.lua
@@ -9,6 +9,8 @@
 --]]--------------------------------------------------------------------------
 
 local lgi = require 'lgi'
+local core = require 'lgi.core'
+local GObject = lgi.GObject
 local Gio = lgi.Gio
 local GLib = lgi.GLib
 
@@ -44,8 +46,22 @@ function progress.file_copy()
 	check_gerror(Gio.File, 'copy_finish', self, result)
 	loop:quit()
     end
-
-    src:copy_async(dst, flags, priority, cancellable,
-		   progress_callback, finish_callback)
+    --
+    -- Fixes https://github.com/lgi-devs/lgi/issues/348
+    --
+    -- Implementation for the fix was a combination
+    -- of ideas from:
+    --
+    -- 1) my own trial-error to find the transition version for GLib (2.82.0)
+    -- 2) Implementation was also partially mirrored from the LGI fork:
+    --      https://github.com/vtrlx/LuaGObject/blob/cd261460f275ea07a4b47cc0c9d0113e17f98b11/tests/progress.lua#L49-L51
+    --
+    if core.repo.GLib.check_version(2, 82, 0) then
+        src:copy_async(dst, flags, priority, cancellable,
+            progress_callback, finish_callback)
+    else
+        src:copy_async(dst, flags, priority, cancellable,
+            GObject.Closure(progress_callback), GObject.Closure(finish_callback))
+    end
     loop:run()
 end

--- a/tests/progress.lua
+++ b/tests/progress.lua
@@ -46,16 +46,6 @@ function progress.file_copy()
 	check_gerror(Gio.File, 'copy_finish', self, result)
 	loop:quit()
     end
-    --
-    -- Fixes https://github.com/lgi-devs/lgi/issues/348
-    --
-    -- Implementation for the fix was a combination
-    -- of ideas from:
-    --
-    -- 1) my own trial-error to find the transition version for GLib (2.82.0)
-    -- 2) Implementation was also partially mirrored from the LGI fork:
-    --      https://github.com/vtrlx/LuaGObject/blob/cd261460f275ea07a4b47cc0c9d0113e17f98b11/tests/progress.lua#L49-L51
-    --
     if core.repo.GLib.check_version(2, 82, 0) then
         src:copy_async(dst, flags, priority, cancellable,
             progress_callback, finish_callback)


### PR DESCRIPTION
## Description

The goal of this PR is to bring back LGI's test suite (`make check`) to the pass state on newer GLib.

* fixes #336
* fixes #348
* fixes #358

I would like to invite @reinerh , @ildar , @ji-cerny to test the proposed changes.

## OS under test

> [!NOTE]
> 
> I used only Lua 5.5.0 on my tests.

1. Ubuntu 24.04.4 LTS (GLib 2.80.0);
2. Ubuntu 24.10 (GLib 2.82.1);
3. Debian 13 trixie (GLib 2.84.4);
4. Debian forky (GLib 2.88.0);